### PR TITLE
Label is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The vocabulary is defined in a YAML file, which contains several block sequences
 Each block sequence consists of blocks with the following keys:`id`, `property`, `value`, `label`, `upper_value`, `domain`, `range`, `deprecated`, `comment`, `status`, `defined_by`, and `see_also`. The interpretation of these key/value pairs may depend on the top level block where they reside, but some have a common interpretation.
 
 - Common key/value pairs for the `class`, `property`, and `individual` blocks:
-  - `label` refers to a short header label to the term.
+  - `label` refers to a short header label to the term. If missing, the capitalized value of `id` is used. 
   - `comment` refers to a longer description of the term, and can be used for blocks in the `class`, `property` and `individual` top-level blocks. It may include [HTML Flow content elements](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories). The comment will be encapsulated into an HTML `<div>` element and will then be displayed verbatim in the HTML version of the vocabulary, and as a literal of type `rdf:HTML` in the JSON-LD and Turtle versions. Note that the Markdown syntax for simple formatting, like the use of "`" for `<code.../>`, may also be used.
   - `defined_by` should be a URL, referring to the formal definition of the term.
   - `see_also` refers to one or more blocks with `label` and `url` keys, providing a human readable title and a URL, respectively, to an external document that can be referred to by the description of the term. (These are translated into an `rdfs:seeAlso` term in the vocabulary.)

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -101,7 +101,7 @@ export interface RawVocabEntry {
     id           : string;
     property    ?: string;
     value       ?: string;
-    label        : string;
+    label       ?: string;
     upper_value ?: string[];
     domain      ?: string[];
     range       ?: string[];

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -179,11 +179,20 @@ function finalizeRawEntry(raw: RawVocabEntry): RawVocabEntry {
         }
     })();
 
+    const label = ((str: string|undefined): string => {
+        if (str) {
+            return str;
+        } else if (raw.id && raw.id.length > 0) {
+            return raw.id[0].toLocaleUpperCase() + raw.id.substring(1);
+        } else {
+            return ""
+        }
+    })(raw.label);
     return {
         id          : (raw.id) ? raw.id : "",
         property    : raw.property,
         value       : raw.value,
-        label       : (raw.label) ? raw.label : "",
+        label       : label,
         upper_value : toArray(raw.upper_value),
         domain      : toArray(raw.domain),
         range       : toArray(raw.range),

--- a/lib/vocab.schema.json
+++ b/lib/vocab.schema.json
@@ -160,8 +160,7 @@
                 }
             },
             "required": [
-                "id",
-                "label"
+                "id"
             ],
             "anyOf": [
                 { "required": ["comment"]    },


### PR DESCRIPTION
Fix #19 

The only minor difference compared to what was proposed in #19 is to use the _capitalized_ version of the `id` value.