### PR TITLE
Minimal changes to make it compatible with the deno version

### DIFF
--- a/example/test.html
+++ b/example/test.html
@@ -110,7 +110,7 @@
         <a rel="alternate" href="vocabulary.jsonld">JSON-LD</a>.
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date" id="time">2023-12-13</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date" id="time">2023-12-15</time></dd>
         <dt>Version Info:</dt>
         <dd>2.0</dd>
         <dt id="see_also">See Also: <a href="https://www.w3.org/TR/vc-data-integrity/" property="rdfs:seeAlso">https://www.w3.org/TR/vc-data-integrity/</a></dt>

--- a/example/test.jsonld
+++ b/example/test.jsonld
@@ -86,7 +86,7 @@
         "@language": "en"
     },
     "rdfs:seeAlso": "https://www.w3.org/TR/vc-data-integrity/",
-    "dc:date": "2023-12-13",
+    "dc:date": "2023-12-15",
     "rdfs_classes": [
         {
             "@id": "sec:Proof",

--- a/example/test.ttl
+++ b/example/test.ttl
@@ -13,7 +13,7 @@ sec: a owl:Ontology ;
     dc:description """vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs 
 """@en ;
     rdfs:seeAlso <https://www.w3.org/TR/vc-data-integrity/> ;
-    dc:date "2023-12-13"^^xsd:date ;
+    dc:date "2023-12-15"^^xsd:date ;
 .
 
 # Class definitions

--- a/index.ts
+++ b/index.ts
@@ -31,7 +31,6 @@ export class VocabGeneration {
         return toTurtle(this.vocab);
     }
 
-
     /**
      * Get the JSON-LD representation of the vocabulary
      * 
@@ -110,7 +109,6 @@ export async function generateVocabularyFiles(yaml_file_name: string, template_f
     }
 
     try {
-
         const conversion: VocabGeneration = new VocabGeneration(yaml);
 
         {

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -101,7 +101,7 @@ export interface RawVocabEntry {
     id           : string;
     property    ?: string;
     value       ?: string;
-    label       ?: string;
+    label        : string;
     upper_value ?: string[];
     domain      ?: string[];
     range       ?: string[];

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -185,7 +185,7 @@ function finalizeRawEntry(raw: RawVocabEntry): RawVocabEntry {
         } else if (raw.id && raw.id.length > 0) {
             return raw.id[0].toLocaleUpperCase() + raw.id.substring(1);
         } else {
-            return ""
+            return "";
         }
     })(raw.label);
     return {

--- a/lib/sys/minidom_node.ts
+++ b/lib/sys/minidom_node.ts
@@ -1,0 +1,93 @@
+/**
+ * Parsing module for HTML — Node.js version using JSDOM
+ * 
+ * @packageDocumentation
+ */
+import { JSDOM } from 'jsdom';
+
+/**
+ * A thin layer on top of the regular DOM Document. Necessary to "hide" the differences between
+ * the JSDOM and Deno's DOM WASM implementations; higher layers should not depend on these.
+ * 
+ * This version is on top of the Deno implementation.
+ * 
+ */
+export class MiniDOM {
+    private _document: Document;
+
+    constructor(html_text: string) {
+        const doc = (new JSDOM(html_text)).window.document;
+        if (doc) {
+            this._document = doc;
+        } else {
+            throw new Error("Problem with parsing the template text");
+        }
+    }
+
+    get document(): Document {
+        return this._document;
+    }
+
+    /**
+     * Add a new HTML Element to a parent, and return the new element.
+     * 
+     * @param parent - The parent HTML Element
+     * @param element - The new element's name
+     * @param content - The new element's (HTML) content
+     * @returns the new element
+     * 
+     */
+    addChild(parent: Element, element: string, content: string | undefined = undefined): Element {
+        const new_element = this._document.createElement(element);
+        parent.appendChild(new_element);
+        if (content !== undefined) new_element.innerHTML = content;
+        return new_element;
+    }
+
+    /**
+     * Add some text to an element, including the obligatory checks that Typescript imposes
+     * 
+     * @param content - text to add
+     * @param element HTML Element to add it to
+     * @returns 
+     * 
+     * @internal
+     */
+    addText(content: string, element: Element | null): Element | null {
+        if (element) {
+            element.textContent = content;
+        }
+        return element;
+    }
+
+    /**
+     * Just the mirroring of the official DOM call.
+     * 
+     * @param id 
+     * @returns 
+     */
+    getElementById(id: string): Element | null {
+        return this._document.getElementById(id);
+    }
+
+    /**
+      * Just the mirroring of the official DOM call.
+      * 
+      * @param tag 
+      * @returns 
+      */
+    getElementsByTagName(tag: string): HTMLCollection {
+        return this._document.getElementsByTagName(tag);
+    }
+
+    /**
+     * Just the mirroring of the official DOM call.
+     * 
+     * @returns 
+     */
+    innerHTML(): string {
+        const retval = this._document.documentElement?.innerHTML;
+        return retval ? retval : "";
+    }
+
+}

--- a/lib/vocab.schema.json
+++ b/lib/vocab.schema.json
@@ -1,5 +1,6 @@
  {
     "$id": "https://github.com/w3c/yml2vocab/lib/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$comment": "This schema depends on JSON Schema draft-2019-09 version",
     "title": "Schema for the vocabulary definition using YAML",
     "description": "See https://w3c.github.io/yml2vocab for a human readable version of the format.",


### PR DESCRIPTION
Made some minimal changes to make the code maximally reusable with Deno as well. The changes here are not changing the functionality, just making some code change.

For the background, the reasons for changes, and the description of the differences, see [derived, Deno version](https://github.com/iherman/yml2vocab-d). 

Just to be on the safe side, I set a DO NOT MERGE flag for now; I will use the local version for generating previews, etc, with 'real' vocabularies; better use those before we possibly jeopardize any current VCDM or DI deployments...

Cc @BigBlueHat 