### PR TITLE
Add 3rd party tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,7 @@ The following files and directories are generated/modified by either the script 
 ## Acknowledgement
 
 The original idea, structure, and script (in Ruby) was created by Gregg Kellogg for v1 of the Credentials Vocabulary and with a vocabulary definition using CSV. The CSV definitions have been changed to YAML, and the script itself has been re-written in TypeScript (and developed further since).
+
+## 3rd party tooling
+- [LEXREX](https://lexrex.web.app/) - supports yml2vocab export/import 
+


### PR DESCRIPTION
Hi, 
I hope you don't mind sharing LEXREX, a visual tool supporting yml2vocab as export/import format. I've found no other way how to let authors of yml2vocab know,  please feel free to close this PR.

LEXREX (~ Lexicon Rex) - semantic vocabularies visual builder and manager

selected features:
- term search | index | suggestions
- multi-vocab ready
- provided/built-in vocabs: schema, foaf, xsd/rdf datatypes
- yml2vocab export/import

https://lexrex.web.app/

It's an experiment, PoC, especially the UI/UX. Just a simple app you can use without login, data is stored locally. Feedback is very appreciated and welcomed. Especially if you are the target audience and think this is a dead end.