### PR TITLE
Clean up code

### DIFF
--- a/lib/context.ts
+++ b/lib/context.ts
@@ -56,6 +56,7 @@ export function toContext(vocab: Vocab): string {
         // to set these in the context as well
         if (property.range) {
             for (const range of property.range) {
+                const [range_prefix, range_reference] = range.split(":");
                 if (range.startsWith("xsd:")) {
                     output["@type"] = range.replace("xsd:", "http://www.w3.org/2001/XMLSchema#");
                     break;
@@ -70,12 +71,16 @@ export function toContext(vocab: Vocab): string {
                     break;
                 } else if (property.type.includes("owl:DatatypeProperty")) {
                     // This is the case when the property refers to an explicitly defined, non-standard datatype
-                    const [range_prefix, range_reference] = range.split(":");
                     const range_url = prefix_url(range_prefix, vocab)
                     output["@type"] = range_url + range_reference;
                     break;
+                } else {
+                    // if range is a class, then it is a reference
+                    if (vocab.classes.find(cl => cl.id === range_reference)) {
+                        output["@type"] = "@id";
+                        break;
+                    }
                 }
-
             } 
         }
         if (property.dataset) {

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -115,10 +115,12 @@ export function toContext(vocab: Vocab): string {
         const prefixed_id = `${global.vocab_prefix}:${cl.id}`;
         // Get all the properties that have this class in its domain
         for (const prop of vocab.properties) {
-            if (prop.domain && prop.domain.includes(prefixed_id)) {
-                // bingo, this property can be added here
-                embedded[prop.id] = propertyContext(prop);
-                class_properties.add(prop.id);
+            if (prop.domain) {
+                if (prop.domain.includes(prefixed_id) || prop.domain.includes(cl.id)) {
+                    // bingo, this property can be added here
+                    embedded[prop.id] = propertyContext(prop);
+                    class_properties.add(prop.id);
+                }
             }
         }
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -103,7 +103,9 @@ export function toContext(vocab: Vocab): string {
     // Add the classes; note that this will also cover the mapping of
     // all properties whose domain include a top level class
     for (const cl of vocab.classes) {
-        const url = `${global.vocab_url}${cl.id}`;
+        const base_url = cl.prefix ? prefix_url(cl.prefix, vocab) : global.vocab_url;
+        const url = `${base_url}${cl.id}`;
+
         // Create an embedded context for the class
         // starting with the preamble and the final URL for the class
         const embedded: Context = {
@@ -112,7 +114,7 @@ export function toContext(vocab: Vocab): string {
 
         // The domain field in the property structure contains
         // the prefixed version of the class ID...
-        const prefixed_id = `${global.vocab_prefix}:${cl.id}`;
+        const prefixed_id = `${cl.prefix}:${cl.id}`;
         // Get all the properties that have this class in its domain
         for (const prop of vocab.properties) {
             if (prop.domain) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yml2vocab",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Generation of vocabulary files starting by YAML",
   "homepage": "https://github.com/w3c/yml2vocab",
   "repository": {


### PR DESCRIPTION
@msporny, I found a clumsiness in the context generation: it required a curie even for local terms in the domain definitions to be able to generate embedded contexts. That is why the identification context was so flat.

This PR takes care of that.