### PR TITLE
Generated context handling issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This list does not include all the tiny changes, bug handling, etc, only the changes in the main features.
 
+## Version 1.8.2
+
+- If applicable, the reference to the generated context file is also linked from the HTML header and, if requested, added to the HTML content.
+
 ## Version 1.8.1
 
 - A term that is defined with a bona fide URL must be referred to from the HTML output with that URL (not with a local reference with a hash)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 
 - If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
 - [Bug] The value of the JSON-LD `"@version"` must be 1.1 (as a number) and not "1.1" (as a string)
+- [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files. (This also means the previous item is moot, there is no need to add a `@version`.)
 
 ## Version 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,13 +1,13 @@
 # Changes
 
-This list does not include all the tiny changes, bug handling, etc, only the changes in the main features.
+This list does not include all the tiny, e.g., editorial changes, only the changes in the features.
 
 ## Version 1.8.2
 
-- If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
+- If applicable, the reference to the generated context file is, if requested via an appropriate ID in the template, added to the HTML content.
 - [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
-- Special actions when the `rdf:langString` is part of the range:
-    - the `rdf:dirLangString` is added to the range as a future-proof feature eyeing towards RDF 1.2
+- Special actions when the `rdf:langString` or `rdf:dirLangString` are part of the range:
+    - both are added to the range (if necessary) as a future-proof feature eyeing towards RDF 1.2
     - if the `range_union` flag is not set to `true` an error is raised, because that is the only way this can work in practice
     - in the generated context the property should only have an `id`, even if it is combined with `xsd:string`; otherwise the language/directions tags will be ignored
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 
 - If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
 - [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
-- Introduced the artificial range `langString` to denote a property whose values are natural language strings. The main issue is that these properties should only have an id value defined in the generated context file, otherwise type coercion will remove the effects of language and direction setting. Additionally, the range will be set to the union of `xsd:string`, `rdf:langString`, and `rdf:dirLangString` in the vocabulary specifications.
+- Introduced the artificial range `langString` to denote a property whose values are natural language strings. The main issue is that these properties should only have an `id` value defined in the generated context file, otherwise type coercion will remove the effects of language and direction setting. An English remark is generated in the HTML text.
 
 ## Version 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 ## Version 1.8.2
 
 - If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
+- [Bug] The value of the JSON-LD `"@version"` must be 1.1 (as a number) and not "1.1" (as a string)
 
 ## Version 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@ This list does not include all the tiny, e.g., editorial changes, only the chang
 - [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
 - Special actions when the `rdf:langString` or `rdf:dirLangString` are part of the range:
     - both are added to the range (if necessary) as a future-proof feature eyeing towards RDF 1.2
-    - if the `range_union` flag is not set to `true` an error is raised, because that is the only way this can work in practice
-    - in the generated context the property should only have an `id`, even if it is combined with `xsd:string`; otherwise the language/directions tags will be ignored
+    - if these types are part of an array of range references, and the `range_union` flag is not set to `true`, an error is raised, because that is the only way these can work in practice
+    - in the generated context the property should only have an `id` (i.e., no datatype is added, even if it is combined with `xsd:string`); otherwise the language/directions tags will be ignored
 
 ## Version 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 
 ## Version 1.8.2
 
-- If applicable, the reference to the generated context file is also linked from the HTML header and, if requested, added to the HTML content.
+- If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
 
 ## Version 1.8.1
 
@@ -17,7 +17,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 ## Version 1.7.1
 
 - Added the `import` block to the `json_ld` top level block, to allow adding a `@import` statement with one or more URI-s at the top of the generated context file.
-- When generating a context file with an aliased term (see the `known_as` property) an extra information is added to the generated HTML file.
+- When generating a context file with an aliased term (see the `known_as` property) extra information added to the generated HTML file.
 - Added the capability to handle HTML templates containing HTML fragments only. The result can be imported into a specification instead of keeping it as a separate file.
 - Introduced the `upper_union` and `range_union` boolean flags for classes and, respectively, properties. If set to `true`, the superclass, respectively range settings with several class references mean the _disjunction_ of the classes, as opposed to the (default) _conjunction_. This formally affects the turtle and json-ld versions of the vocabulary (which use the `owl:unionOf` construct); the HTML description uses now the ⊓ and ⊔ characters to denote these. This allows to say: "instances of this class are of type either this, this, or this".
 - Introduced the `one_of` keys for classes, datatypes, and property ranges. The values list the possible individuals for a class (including a range), and the possible string values for a datatype derived from `xsd:string`. Furthermore, the `pattern` key for a datatype can hold a regular expression restricting the acceptable string value.
@@ -26,7 +26,7 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 
 ## Version 1.7.0
 
-- The package does not generate RDFa any more. The usage of RDFa in the HTML represented a significant burden on the code itself, and also made the generated HTML messy. All this for no real benefit: RDFa is very rarely used these days. Instead, the JSON-LD and Turtle versions of the vocabulary are linked from the HTML header as alternate representations.
+- The package does not generate RDFa anymore. The usage of RDFa in the HTML represented a significant burden on the code itself, and also made the generated HTML messy. All this for no real benefit: RDFa is very rarely used these days. Instead, the JSON-LD and Turtle versions of the vocabulary are linked from the HTML header as alternate representations.
 - All the generated files (HTML, Turtle, JSON-LD) are formatted by, partially, taking into account a possible [`.editorconfig`](https://spec.editorconfig.org) file regarding indentation size and some more, minor control statements.
 - Added the `container` key for properties, with a possible value of `set` or `list`. These values appear, for the specific property, in the generated JSON-LD `@context` file. In the `list` case it will also affect the range of the property (which is set to `rdf:List`).
 - Added the `json_ld` top level block with the `alias` block, defining keys to alias some JSON-LD keywords in the generated context file.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,8 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 ## Version 1.8.2
 
 - If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
-- [Bug] The value of the JSON-LD `"@version"` must be 1.1 (as a number) and not "1.1" (as a string)
-- [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files. (This also means the previous item is moot, there is no need to add a `@version`.)
+- [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
+- Introduced the artificial range `langString` to denote a property whose values are natural language strings. The main issue is that these properties should only have an id value defined in the generated context file, otherwise type coercion will remove the effects of language and direction setting. Additionally, the range will be set to the union of `xsd:string`, `rdf:langString`, and `rdf:dirLangString` in the vocabulary specifications.
 
 ## Version 1.8.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,10 @@ This list does not include all the tiny changes, bug handling, etc, only the cha
 
 - If applicable, the reference to the generated context file is, if requested via an appropriate ID, added to the HTML content.
 - [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
-- Introduced the artificial range `langString` to denote a property whose values are natural language strings. The main issue is that these properties should only have an `id` value defined in the generated context file, otherwise type coercion will remove the effects of language and direction setting. An English remark is generated in the HTML text.
+- Special actions when the `rdf:langString` is part of the range:
+    - the `rdf:dirLangString` is added to the range as a future-proof feature eyeing towards RDF 1.2
+    - if the `range_union` flag is not set to `true` an error is raised, because that is the only way this can work in practice
+    - in the generated context the property should only have an `id`, even if it is combined with `xsd:string`; otherwise the language/directions tags will be ignored
 
 ## Version 1.8.1
 

--- a/README.md
+++ b/README.md
@@ -483,11 +483,11 @@ class:
     </tbody>
 </table>
 
-Note that if the range includes the `rdf:langString`, then the property value is expected to be a natural language string. This has the following effects:
+Note that if the range includes the `rdf:langString` or `rdf:dirLangString` datatypes, then the property value is expected to be, possibly, a natural language string. This has the following effects:
 
 - In the case the range also includes another datatype (typically `xsd:string`) then the `range_union` flag must be set to `true` (`xsd:langString` does not "intersect" with any other type).
-- The `rdf:dirLangString` is added to the range array (this datatype is introduced in RDF 1.2).
-- No type is added in the generated context file so that the JSON-LD handling of language and direction would not be overshadowed by [type coercion](https://www.w3.org/TR/json-ld11).
+- Both types are added to the range array, if necessary.
+- No type is added in the generated context file so that the JSON-LD handling of language and direction would not be overshadowed by [type coercion](https://www.w3.org/TR/json-ld11#string-internationalization).
 - A comment is added to the HTML version of the vocabulary whereby the value is expected to be a natural language text.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -606,31 +606,32 @@ The generation of the HTML output requires an HTML Template file. This can eithe
 
 The required `id` values, and the containing elements, are as follows:
 
-| `id` value                          | Corresponding element | Generated content                                                                      |
-| :---------------------------------- | --------------------- | :------------------------------------------------------------------------------------- |
-| `title` or `ontology_title`         | any textual           | The title/name of the vocabulary (see the `ontology` block)                            |
-| `description`                       | any textual           | The description of the vocabulary (see the `ontology` block)                           |
-| `see_also`                          | any textual           | External reference for the vocabulary (see the `ontology` block)                       |
-| `alt-turtle`                        | `<a>`                 | Add a reference to the Turtle version of the vocabulary as an `href` attribute value   |
-| `alt-jsonld`                        | `<a>`                 | Add a reference to the JSON-LD version of the vocabulary  as an `href` attribute value |
-| `time`                              | any textual           | Date of the vocabulary generation                                                      |
-| `namespaces`                        | `<dl>`                | List of namespaces used by the vocabulary                                              |
-| `contexts`                          | `<ul>`                | List of context files where the vocabulary terms appear                                |
-| `term_definitions`                  | `<section>`           | Section for the fully defined vocabulary terms                                         |
-| `class_definitions`                 | `<section>`           | Subsection for the fully defined classes                                               |
-| `property_definitions`              | `<section>`           | Subsection for the fully defined properties                                            |
-| `datatype_definitions`              | `<section>`           | Subsection for the fully defined datatypes                                             |
-| `individual_definitions`            | `<section>`           | Subsection for the fully defined individuals                                           |
-| `reserved_term_definitions`         | `<section>`           | Section for the reserved vocabulary terms                                              |
-| `reserved_class_definitions`        | `<section>`           | Subsection for the reserved classes                                                    |
-| `reserved_property_definitions`     | `<section>`           | Subsection for the reserved properties                                                 |
-| `reserved_datatype_definitions`     | `<section>`           | Subsection for the reserved datatypes                                                  |
-| `reserved_individual_definitions`   | `<section>`           | Subsection for the reserved individuals                                                |
-| `deprecated_term_definitions`       | `<section>`           | Section for the deprecated vocabulary terms                                            |
-| `deprecated_class_definitions`      | `<section>`           | Subsection for the deprecated classes                                                  |
-| `deprecated_property_definitions`   | `<section>`           | Subsection for the deprecated properties                                               |
-| `deprecated_datatype_definitions`   | `<section>`           | Subsection for the deprecated datatypes                                                |
-| `deprecated_individual_definitions` | `<section>`           | Subsection for the deprecated individuals                                              |
+| `id` value                          | Corresponding element | Generated content                                                                           |
+| :---------------------------------- | --------------------- | :------------------------------------------------------------------------------------------ |
+| `title` or `ontology_title`         | any textual           | The title/name of the vocabulary (see the `ontology` block)                                 |
+| `description`                       | any textual           | The description of the vocabulary (see the `ontology` block)                                |
+| `see_also`                          | any textual           | External reference for the vocabulary (see the `ontology` block)                            |
+| `alt-turtle`                        | `<a>`                 | Add a reference to the Turtle version of the vocabulary as an `href` attribute value        |
+| `alt-jsonld`                        | `<a>`                 | Add a reference to the JSON-LD version of the vocabulary  as an `href` attribute value      |
+| `alt-context`                       | `<a>`                 | Add a reference to the JSON-LD Context file for the vocabulary as an `href` attribute value |
+| `time`                              | any textual           | Date of the vocabulary generation                                                           |
+| `namespaces`                        | `<dl>`                | List of namespaces used by the vocabulary                                                   |
+| `contexts`                          | `<ul>`                | List of context files where the vocabulary terms appear                                     |
+| `term_definitions`                  | `<section>`           | Section for the fully defined vocabulary terms                                              |
+| `class_definitions`                 | `<section>`           | Subsection for the fully defined classes                                                    |
+| `property_definitions`              | `<section>`           | Subsection for the fully defined properties                                                 |
+| `datatype_definitions`              | `<section>`           | Subsection for the fully defined datatypes                                                  |
+| `individual_definitions`            | `<section>`           | Subsection for the fully defined individuals                                                |
+| `reserved_term_definitions`         | `<section>`           | Section for the reserved vocabulary terms                                                   |
+| `reserved_class_definitions`        | `<section>`           | Subsection for the reserved classes                                                         |
+| `reserved_property_definitions`     | `<section>`           | Subsection for the reserved properties                                                      |
+| `reserved_datatype_definitions`     | `<section>`           | Subsection for the reserved datatypes                                                       |
+| `reserved_individual_definitions`   | `<section>`           | Subsection for the reserved individuals                                                     |
+| `deprecated_term_definitions`       | `<section>`           | Section for the deprecated vocabulary terms                                                 |
+| `deprecated_class_definitions`      | `<section>`           | Subsection for the deprecated classes                                                       |
+| `deprecated_property_definitions`   | `<section>`           | Subsection for the deprecated properties                                                    |
+| `deprecated_datatype_definitions`   | `<section>`           | Subsection for the deprecated datatypes                                                     |
+| `deprecated_individual_definitions` | `<section>`           | Subsection for the deprecated individuals                                                   |
 
 If an element is missing, the content is ignored by the script.
 

--- a/README.md
+++ b/README.md
@@ -449,10 +449,7 @@ class:
                 The RDF domain statements of the property. If the <code >URL</code> (alternatively: <code >IRI</code>) term is used, the block
                 defines a property that has no explicit range type, but whose objects are expected to be IRI references. The generated vocabularies
                 annotate these properties as belonging to the <code >owl:ObjectProperty</code> class, which is the reserved term for properties
-                whose objects are not supposed to be literals. A corresponding comment is also generated into the HTML description of the term.<br/>
-                If the <code>langString</code> term is used, the block defines a property that has a union type of <code>rdf:langString</code> or
-                <code>rdf:dirLangString</code>; no type is added in the generated context file so that the JSON-LD handling of language and
-                direction would not be overshadowed by <a href="https://www.w3.org/TR/json-ld11/#type-coercion">type coercion</a>.
+                whose objects are not supposed to be literals. A corresponding comment is also generated into the HTML description of the term.
             </td>
             <td>No</td>
         </tr>
@@ -486,6 +483,12 @@ class:
     </tbody>
 </table>
 
+Note that if the range includes the `rdf:langString`, then the property value is expected to be a natural language string. This has the following effects:
+
+- In the case the range also includes another datatype (typically `xsd:string`) then the `range_union` flag must be set to `true` (`xsd:langString` does not "intersect" with any other type).
+- The `rdf:dirLangString` is added to the range array (this datatype is introduced in RDF 1.2).
+- No type is added in the generated context file so that the JSON-LD handling of language and direction would not be overshadowed by [type coercion](https://www.w3.org/TR/json-ld11).
+- A comment is added to the HTML version of the vocabulary whereby the value is expected to be a natural language text.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ class:
         </tr>
         <tr>
             <td><code>range</code></td>
-            <td>One or more terms or CURIES, the single <code>URL</code> term, or the single <code>langString</code> term</td>
+            <td>One or more terms or CURIES or the single <code>URL</code> term</td>
             <td>
                 The RDF domain statements of the property. If the <code >URL</code> (alternatively: <code >IRI</code>) term is used, the block
                 defines a property that has no explicit range type, but whose objects are expected to be IRI references. The generated vocabularies

--- a/README.md
+++ b/README.md
@@ -444,12 +444,15 @@ class:
         </tr>
         <tr>
             <td><code>range</code></td>
-            <td>One or more terms or CURIES, or the single <code>URL</code> term</td>
+            <td>One or more terms or CURIES, the single <code>URL</code> term, or the single <code>langString</code> term</td>
             <td>
                 The RDF domain statements of the property. If the <code >URL</code> (alternatively: <code >IRI</code>) term is used, the block
                 defines a property that has no explicit range type, but whose objects are expected to be IRI references. The generated vocabularies
                 annotate these properties as belonging to the <code >owl:ObjectProperty</code> class, which is the reserved term for properties
-                whose objects are not supposed to be literals. A corresponding comment is also generated into the HTML description of the term.
+                whose objects are not supposed to be literals. A corresponding comment is also generated into the HTML description of the term.<br/>
+                If the <code>langString</code> term is used, the block defines a property that has a union type of <code>rdf:langString</code> or
+                <code>rdf:dirLangString</code>; no type is added in the generated context file so that the JSON-LD handling of language and
+                direction would not be overshadowed by <a href="https://www.w3.org/TR/json-ld11/#type-coercion">type coercion</a>.
             </td>
             <td>No</td>
         </tr>
@@ -463,6 +466,7 @@ class:
                 in the list.
                 <br>The entries are required to refer to individuals.
             </td>
+            <td>No</td>
         </tr>
         <tr>
             <td><code>range_union</code></td>
@@ -564,7 +568,6 @@ individual:
             <td>"Super" datatypes that this datatype is derived from. The term `type` can also be used, as an alias to this term</td>
             <td>No</td>
         </tr>
-
     </tbody>
 </table>
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "@iherman/yml2vocab",
     "description": "Generation of vocabulary files starting by YAML",
-    "version": "1.8.1",
+    "version": "1.8.22",
     "homepage": "https://github.com/w3c/yml2vocab",
     // We do not want to use the npm installation from deno
     // npm packages used by the code is maintained separately

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,9 +17,10 @@
     "tasks": {
         "local_vcdm_nolink": "(cd local/tests/vcdm;  deno run --quiet --allow-all ../../../main.ts -c)",
         "local_test": "(cd local/tests;  deno run --quiet --allow-all ../../main.ts -v test.yml -t test_template.html -c)",
-        "local_ident": "(cd local/tests/identification;  deno run --quiet --allow-all ../../../main.ts -c)",
-        "local_did": "(cd local/tests/did;  deno run --quiet --allow-all ../../../main.ts -c)",
-        "local_ea": "(cd local/tests/epub;  deno run --quiet --allow-all ../../../main.ts -c)",
+        "local_test_ident": "(cd local/tests/identification;  deno run --quiet --allow-all ../../../main.ts -c)",
+        "local_test_did": "(cd local/tests/did;  deno run --quiet --allow-all ../../../main.ts -c)",
+        "local_test_epub": "(cd local/tests/epub;  deno run --quiet --allow-all ../../../main.ts -c -v index)",
+        "local_epub": "(cd local/epub;  deno run --quiet --allow-all ../../../main.ts -c -v index)",
         "compile": "deno compile --allow-all --quiet main.ts"
     },
     "exports": {

--- a/index.ts
+++ b/index.ts
@@ -17,13 +17,14 @@
  * @module
  */
 
-import { Vocab }          from './lib/common';
+import type { Vocab }     from './lib/common';
 import { getData }        from "./lib/convert";
 import { toTurtle }       from "./lib/turtle";
 import { toJSONLD }       from './lib/jsonld';
 import { toHTML }         from './lib/html';
 import { toContext }      from './lib/context';
 import { promises as fs } from 'node:fs';
+import { join } from "node:path";
 
 
 /**
@@ -106,9 +107,10 @@ export class VocabGeneration {
  * @param yaml_file_name - the vocabulary file in YAML
  * @param template_file_name - the HTML template file
  * @param context - whether the JSON-LD context file should also be generated
+ * @param debug - display a full stack if an error is reported
  * @throws on error situation in reading the input files, in yml validation, or when writing the result
  */
-export async function generateVocabularyFiles(yaml_file_name: string, template_file_name: string, context: boolean): Promise<void> {
+export async function generateVocabularyFiles(yaml_file_name: string, template_file_name: string, context: boolean, debug = false): Promise<void> {
     // This trick allows the user to give the full yaml file name, or only the common base
     const basename = yaml_file_name.endsWith('.yml') ? yaml_file_name.slice(0,-4) : yaml_file_name;
 
@@ -132,14 +134,16 @@ export async function generateVocabularyFiles(yaml_file_name: string, template_f
         read_errors.push(reads[1].reason);
     }
 
-    if (read_errors.length !== 0) {
-        // One of the two files could not be read, we should abort here:
-        throw(new AggregateError(read_errors.join('\n')));
-    }
 
     try {
-        const conversion: VocabGeneration = new VocabGeneration(yaml);
+        // Pushing this here, to have a unified error reporting point below.
 
+        if (read_errors.length !== 0) {
+            // One of the two files could not be read, we should abort here:
+            throw new Error(read_errors.join(" "));
+        }
+
+        const conversion: VocabGeneration = new VocabGeneration(yaml);
         const fs_writes: Promise<void>[] = [
             fs.writeFile(`${basename}.ttl`, conversion.getTurtle()),
             fs.writeFile(`${basename}.jsonld`, conversion.getJSONLD()),
@@ -154,11 +158,15 @@ export async function generateVocabularyFiles(yaml_file_name: string, template_f
 
         if (write_errors.length != 0) {
             // One or more files could not be written, we should throw an exception...
-            throw(new AggregateError(write_errors.join('\n')));
+            throw(new Error(write_errors.join(" ")));
         }
     // deno-lint-ignore no-explicit-any
     } catch(e: any) {
-        console.error(`Error in the YML conversion:\n${e.message}\nCause: ${e.cause}\nStack: ${e.stack}`);
+        if (debug) {
+            console.error(`Error in the YML conversion:\n${e.message}\nCause: ${e.cause}\nStack: ${e.stack}\n\n`);
+        } else {
+            console.error(`Error in the YML conversion: "${e.message}"\n`);
+        }
     }
 }
 

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -240,8 +240,8 @@ export interface ValidationResults {
 }
 
 /**
- * This is a shortened version of the full Ajv error message (the schema is very simple,
- * the generic Ajv error message is way too complex for our use)
+ * This is a shortened version of the full exodus error message (the schema is very simple,
+ * the generic exodus error message is way too complex for our use)
  */
 export interface ValidationError {
     message ?: string;

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -365,6 +365,7 @@ export interface RDFProperty extends RDFTerm {
     dataset       : boolean;
     container     : Container | undefined;
     strongURL     : boolean;    // Whether the property object should be required to be a real URL
+    langString    : boolean;    // Whether the property gets the artificial range type langString
 }
 
 /**

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -12,7 +12,7 @@ import { beautify }                                        from './beautify';
 
 // Just to get an extra help from TS if I mistype something...
 interface Context {
-    [index: string]: string | string[] | Context | boolean | null;
+    [index: string]: string | string[] | Context | boolean | null | number;
 }
 
 // These are the context statements appearing in all
@@ -114,12 +114,12 @@ export function toContext(vocab: Vocab): string {
             return {};
         } else if( global.import.length === 1) {
             return {
-                "@version" : "1.1",
+                "@version" : 1.1,
                 "@import" : global.import[0]
             }
         } else {
             return {
-                "@version": "1.1",
+                "@version": 1.1,
                 "@import" : global.import
             }
         }

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -43,81 +43,78 @@ function prefix_url(prefix: string | undefined, vocab: Vocab): string {
  */
 export function toContext(vocab: Vocab): string {
     // Generation of a unit for properties
-    const propertyContext = (
-        property: RDFProperty,
-        forClass = true,
-    ): Context | string => {
+    const propertyContext = (property: RDFProperty, forClass = true): Context | string => {
         // the real id of the property...
         const baseUrl = prefix_url(property.prefix, vocab);
         const url = `${baseUrl}${property.id}`;
         const output: Context = {
             "@id": url,
         };
-        if (
-            forClass &&
-            RDFTermFactory.includesCurie(property.type, "owl:ObjectProperty")
-        ) {
+        if (forClass && RDFTermFactory.includesCurie(property.type, "owl:ObjectProperty")) {
             output["@type"] = "@id";
         }
-        // Try to catch the datatype settings; these can be used
-        // to set these in the context as well
-        if (property.range) {
-            for (const rangeTerm of property.range) {
-                const curie = rangeTerm.curie;
-                if (curie.startsWith("xsd:")) {
-                    output["@type"] = rangeTerm.url;
-                    break;
-                } else if (curie === "rdf:JSON") {
-                    output["@type"] = "@json";
-                    break;
-                } else if (
-                    [
-                        "rdf:HTML",
-                        "rdf:XMLLiteral",
-                        "rdf:PlainLiteral",
-                        "rdf:langString",
-                    ].includes(curie)
-                ) {
-                    output["@type"] = rangeTerm.url;
-                    break;
-                } else if (
-                    RDFTermFactory.includesCurie(
-                        property.type,
-                        "owl:DatatypeProperty",
-                    )
-                ) {
-                    // This is the case when the property refers to an explicitly defined, non-standard datatype
-                    output["@type"] = rangeTerm.url;
-                    break;
-                } else {
-                    if (RDFTermFactory.isClass(rangeTerm)) {
-                        output["@type"] = "@id";
+
+        // If the property is explicitly set to be a natural language string,
+        // then no typing should happen, because those would invalidate the
+        // language/direction settings.
+        if (property.langString === false) {
+
+            // Try to catch the datatype settings; these can be used
+            // to set these in the context as well
+            if (property.range) {
+                for (const rangeTerm of property.range) {
+                    const curie = rangeTerm.curie;
+                    if (curie.startsWith("xsd:")) {
+                        output["@type"] = rangeTerm.url;
                         break;
+                    } else if (curie === "rdf:JSON") {
+                        output["@type"] = "@json";
+                        break;
+                    } else if (
+                        [
+                            "rdf:HTML",
+                            "rdf:XMLLiteral",
+                            "rdf:PlainLiteral",
+                            "rdf:langString",
+                            "rdf:dirLangString"
+                        ].includes(curie)
+                    ) {
+                        output["@type"] = rangeTerm.url;
+                        break;
+                    } else if (RDFTermFactory.includesCurie(property.type,"owl:DatatypeProperty")) {
+                        // This is the case when the property refers to an explicitly defined, non-standard datatype
+                        output["@type"] = rangeTerm.url;
+                        break;
+                    } else {
+                        if (RDFTermFactory.isClass(rangeTerm)) {
+                            output["@type"] = "@id";
+                            break;
+                        }
                     }
                 }
             }
-        }
 
-        // There is a special treatment to generate additional statements
-        // when the values of the range are restricted.
-        // Thanks to Pierre-Antoine Champin for this tricky representation of the constraints.
-        if (property.one_of?.length > 0 && !property.dataset) {
-            const mappings = property.one_of.map((term) => [term.id, term.url]);
-            mappings.push(["@vocab", `${global.vocab_prefix}:INVALID_VALUE:`]);
-            // Note that this may overwrite earlier values...
-            output["@type"] = "@vocab";
-            output["@context"] = Object.fromEntries(mappings);
-        }
-
-        if (property.dataset) {
-            if (property.container === Container.set) {
-                output["@container"] = ["@set", "@graph"];
-            } else {
-                output["@container"] = "@graph";
+            // There is a special treatment to generate additional statements
+            // when the values of the range are restricted.
+            // Thanks to Pierre-Antoine Champin for this tricky representation of the constraints.
+            if (property.one_of?.length > 0 && !property.dataset) {
+                const mappings = property.one_of.map((term) => [term.id, term.url]);
+                mappings.push(["@vocab", `${global.vocab_prefix}:INVALID_VALUE:`]);
+                // Note that this may overwrite earlier values...
+                output["@type"] = "@vocab";
+                output["@context"] = Object.fromEntries(mappings);
             }
-            output["@type"] = "@id";
-        } else if (property.container !== undefined) {
-            output["@container"] = `@${property.container}`;
+
+            if (property.dataset) {
+                if (property.container === Container.set) {
+                    output["@container"] = ["@set", "@graph"];
+                } else {
+                    output["@container"] = "@graph";
+                }
+                output["@type"] = "@id";
+            } else if (property.container !== undefined) {
+                output["@container"] = `@${property.container}`;
+            }
         }
 
         // if only the URL is set, it makes the context simpler to use its direct value,

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -12,7 +12,7 @@ import { beautify }                                        from './beautify';
 
 // Just to get an extra help from TS if I mistype something...
 interface Context {
-    [index: string]: string | string[] | Context | boolean | null | number;
+    [index: string]: string | string[] | Context | boolean | null  ;
 }
 
 // These are the context statements appearing in all
@@ -42,16 +42,21 @@ function prefix_url(prefix: string | undefined, vocab: Vocab): string {
  * @returns - the full context in string (ready to be written to a file)
  */
 export function toContext(vocab: Vocab): string {
-
     // Generation of a unit for properties
-    const propertyContext = (property: RDFProperty, forClass = true): Context|string => {
+    const propertyContext = (
+        property: RDFProperty,
+        forClass = true,
+    ): Context | string => {
         // the real id of the property...
         const baseUrl = prefix_url(property.prefix, vocab);
         const url = `${baseUrl}${property.id}`;
         const output: Context = {
-            "@id" : url
-        }
-        if (forClass && RDFTermFactory.includesCurie(property.type, "owl:ObjectProperty")) {
+            "@id": url,
+        };
+        if (
+            forClass &&
+            RDFTermFactory.includesCurie(property.type, "owl:ObjectProperty")
+        ) {
             output["@type"] = "@id";
         }
         // Try to catch the datatype settings; these can be used
@@ -65,15 +70,27 @@ export function toContext(vocab: Vocab): string {
                 } else if (curie === "rdf:JSON") {
                     output["@type"] = "@json";
                     break;
-                } else if (["rdf:HTML", "rdf:XMLLiteral", "rdf:PlainLiteral", "rdf:langString"].includes(curie)) {
+                } else if (
+                    [
+                        "rdf:HTML",
+                        "rdf:XMLLiteral",
+                        "rdf:PlainLiteral",
+                        "rdf:langString",
+                    ].includes(curie)
+                ) {
                     output["@type"] = rangeTerm.url;
                     break;
-                 } else if (RDFTermFactory.includesCurie(property.type, "owl:DatatypeProperty")) {
+                } else if (
+                    RDFTermFactory.includesCurie(
+                        property.type,
+                        "owl:DatatypeProperty",
+                    )
+                ) {
                     // This is the case when the property refers to an explicitly defined, non-standard datatype
                     output["@type"] = rangeTerm.url;
                     break;
-                 } else {
-                     if (RDFTermFactory.isClass(rangeTerm)) {
+                } else {
+                    if (RDFTermFactory.isClass(rangeTerm)) {
                         output["@type"] = "@id";
                         break;
                     }
@@ -98,33 +115,17 @@ export function toContext(vocab: Vocab): string {
             } else {
                 output["@container"] = "@graph";
             }
-            output["@type"]      = "@id";
+            output["@type"] = "@id";
         } else if (property.container !== undefined) {
             output["@container"] = `@${property.container}`;
         }
 
         // if only the URL is set, it makes the context simpler to use its direct value,
         // no need for an indirection
-        return (Object.keys(output).length === 1) ? url: output;
-    }
+        return Object.keys(output).length === 1 ? url : output;
+    };
 
-    // This is the top level context that will be returned to the caller
-    const import_context = ((): Context => {
-        if (global.import.length === 0) {
-            return {};
-        } else if( global.import.length === 1) {
-            return {
-                "@version" : 1.1,
-                "@import" : global.import[0]
-            }
-        } else {
-            return {
-                "@version": 1.1,
-                "@import" : global.import
-            }
-        }
-    })();
-    const top_level: Context = { ...import_context, ...preamble, ...global.aliases };
+    const top_level: Context = { ...preamble, ...global.aliases };
 
     // Set of properties that are "handled" as parts of embedded contexts of classes.
     // This is used to avoid repeating the properties at the top level
@@ -133,13 +134,15 @@ export function toContext(vocab: Vocab): string {
     // Add the classes; note that this will also cover the mapping of
     // all properties whose domain include a top level class
     for (const cl of vocab.classes) {
-        const base_url = cl.prefix ? prefix_url(cl.prefix, vocab) : global.vocab_url;
+        const base_url = cl.prefix
+            ? prefix_url(cl.prefix, vocab)
+            : global.vocab_url;
         const url = `${base_url}${cl.id}`;
 
         // Create an embedded context for the class
         // starting with the preamble and the final URL for the class
         const embedded: Context = {
-            ...preamble
+            ...preamble,
         };
 
         // Get all the properties that have this class in its domain
@@ -154,9 +157,10 @@ export function toContext(vocab: Vocab): string {
         }
 
         // If no properties are added, then the embedded context is unnecessary
-        top_level[cl.known_as ?? cl.id] = (Object.keys(embedded).length === Object.keys(preamble).length)
-            ? url
-            : { "@id": url, "@context": embedded };
+        top_level[cl.known_as ?? cl.id] =
+            Object.keys(embedded).length === Object.keys(preamble).length
+                ? url
+                : { "@id": url, "@context": embedded };
     }
 
     // Add the properties that have not been handled in the
@@ -177,8 +181,21 @@ export function toContext(vocab: Vocab): string {
         top_level[datatype.known_as ?? datatype.id] = `${datatype.url}`;
     }
 
+    // the final shape of the context depends on whether there are imported
+    // contexts or not
+    const final_context = ((): unknown => {
+        if (global.import.length === 0) {
+            return top_level
+        } else {
+            return [
+                ...global.import,
+                top_level
+            ]
+        }
+    })();
+
     // Done... just turn the result into bona fide (and readable) json
-    const final_jsonld = JSON.stringify({ "@context": top_level });
-    const nice_jsonld = beautify(final_jsonld, 'jsonld');
+    const final_jsonld = JSON.stringify({ "@context": final_context });
+    const nice_jsonld = beautify(final_jsonld, "jsonld");
     return nice_jsonld;
 }

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -347,15 +347,21 @@ export function getData(vocab_source: string): Vocab {
     //
     // The function also sets the possible values of a (pure) datatype or object property as extra types
     // to be added to the enclosing property
-    const get_ranges = (factory: RDFTermFactory, raw: RawVocabEntry, id: string): { extra_types: string[], range: RDFTerm[], strongURL: boolean } => {
+    const get_ranges = (factory: RDFTermFactory, raw: RawVocabEntry, id: string): { extra_types: string[], range: RDFTerm[], strongURL: boolean, langString: boolean } => {
         let extra_types: string[] = [];
         const range: RDFTerm[]    = [];
         let strongURL: boolean    = false;
+        let langString: boolean   = false;
 
         if (raw.range && raw.range.length > 0) {
             if (raw.range.length === 1 && (raw.range[0].toUpperCase() === "IRI" || raw.range[0].toUpperCase() === "URL")) {
                 extra_types.push("owl:ObjectProperty");
                 strongURL = true;
+            } else if (raw.range.length === 1 && raw.range[0].toUpperCase() === "LANGSTRING" ) {
+                langString = true;
+                for (const term of ["xsd:string", "rdf:langString", "rdf:dirLangString"]) {
+                    range.push(factory.term(term))
+                }
             } else {
                 for (const rg of raw.range) {
                     if (rg.startsWith("xsd") === true || EXTRA_DATATYPES.find((entry) => entry === rg) !== undefined) {
@@ -393,7 +399,7 @@ export function getData(vocab_source: string): Vocab {
         if (extra_types.length > 1) {
             extra_types = [];
         };
-        return { extra_types, range, strongURL }
+        return { extra_types, range, strongURL, langString }
     }
 
     // Check whether the external term is defined somewhere, ie, a defined by or at least a comment.
@@ -629,7 +635,7 @@ export function getData(vocab_source: string): Vocab {
             global.status_counter.add(raw.status ? raw.status : Status.stable);
 
             // Calculate the ranges, which can be a mixture of classes, datatypes, and unknown terms
-            const { extra_types, range, strongURL } = get_ranges(factory, raw, output.id);
+            const { extra_types, range, strongURL, langString } = get_ranges(factory, raw, output.id);
 
             // A little hack to ensure backward compatibility: if the range includes rdf:List,
             // it should be removed and the information put aside because that should now
@@ -684,7 +690,7 @@ export function getData(vocab_source: string): Vocab {
                 subPropertyOf : raw.upper_value?.map((val: string): RDFProperty => factory.property(val)),
                 see_also      : raw.see_also,
                 range         : finalRange,
-                range_union   : raw.range_union,
+                range_union   : (langString === true) ? true : raw.range_union,
                 one_of        : raw.one_of?.map((val: string): RDFIndividual => factory.individual(val)),
                 domain        : raw.domain?.map(val => factory.class(val)),
                 example       : raw.example,
@@ -692,6 +698,7 @@ export function getData(vocab_source: string): Vocab {
                 dataset       : dataset,
                 container     : container,
                 strongURL     : strongURL,
+                langString    : langString,
                 context       : final_contexts(raw, output),
             });
             return output;

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -359,7 +359,9 @@ export function getData(vocab_source: string): Vocab {
                 strongURL = true;
             } else if (raw.range.length === 1 && raw.range[0].toUpperCase() === "LANGSTRING" ) {
                 langString = true;
-                for (const term of ["xsd:string", "rdf:langString", "rdf:dirLangString"]) {
+                // commenting this thing out. Not clear whether this makes any sense in practice; another
+                // effect is to generate an additional remark in the HTML version of the vocabulary
+                for (const term of ["rdf:langString", "rdf:dirLangString"]) {
                     range.push(factory.term(term))
                 }
             } else {

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -367,6 +367,7 @@ export function getData(vocab_source: string): Vocab {
                 }
                 // As a future-proof action adding both RDF lang strings to the mix, but avoiding duplications
                 const frange = new Set([...raw.range, "rdf:langString", "rdf:dirLangString"]);
+                raw.range_union = true;            // this may be necessary if the original included one setting only
                 for (const term of frange) {
                     range.push(factory.term(term));
                 }

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -296,9 +296,10 @@ export function getData(vocab_source: string): Vocab {
     // generated object if everything is fine.
     const validation_results: ValidationResults = validateWithSchema(vocab_source);
     if (validation_results.vocab === null) {
-        const error = JSON.stringify(validation_results.error, null, 4);
-        throw(new TypeError(`JSON Schema validation error`, {cause: '\n' + error}));
+        const error = JSON.stringify(validation_results.error, null, 2);
+        throw(new TypeError(`${error}`, {cause: '\n' + error}));
     }
+
     // Clean up the raw vocab representation.
     const vocab: RawVocab = finalizeRawVocab(validation_results.vocab);
 

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -357,11 +357,16 @@ export function getData(vocab_source: string): Vocab {
             if (raw.range.length === 1 && (raw.range[0].toUpperCase() === "IRI" || raw.range[0].toUpperCase() === "URL")) {
                 extra_types.push("owl:ObjectProperty");
                 strongURL = true;
-            } else if (raw.range.length === 1 && raw.range[0].toUpperCase() === "LANGSTRING" ) {
+            } else if (raw.range.includes("rdf:langString") ) {
                 langString = true;
-                // commenting this thing out. Not clear whether this makes any sense in practice; another
-                // effect is to generate an additional remark in the HTML version of the vocabulary
-                for (const term of ["rdf:langString", "rdf:dirLangString"]) {
+                if (raw.range.length > 1 && raw.range_union === false) {
+                    throw new Error(
+                        `The range ${raw.range} of the property ${raw.id} includes rdf:langString, but the range union flag is not set`,
+                    );
+                }
+                // As a future-proof action adding rdf:dirLangString to the mix (coming up in RDF 1.1)
+                const frange = raw.range.includes("rdf:dirLangString") ? raw.range : [...raw.range, "rdf:dirLangString"];
+                for (const term of frange) {
                     range.push(factory.term(term))
                 }
             } else {

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -358,21 +358,25 @@ export function getData(vocab_source: string): Vocab {
             if (raw.range.length === 1 && (raw.range[0].toUpperCase() === "IRI" || raw.range[0].toUpperCase() === "URL")) {
                 extra_types.push("owl:ObjectProperty");
                 strongURL = true;
-            } else if (raw.range.includes("rdf:langString") ) {
+            } else if (raw.range.includes("rdf:langString") || raw.range.includes("rdf:dirLangString")) {
                 langString = true;
                 if (raw.range.length > 1 && raw.range_union === false) {
                     throw new Error(
-                        `The range ${raw.range} of the property ${raw.id} includes rdf:langString, but the range union flag is not set`,
+                        `The range ${raw.range} of the property ${raw.id} includes rdf:langString or rdf:dirLangString, but the range union flag is not set`,
                     );
                 }
-                // As a future-proof action adding rdf:dirLangString to the mix (coming up in RDF 1.1)
-                const frange = raw.range.includes("rdf:dirLangString") ? raw.range : [...raw.range, "rdf:dirLangString"];
+                // As a future-proof action adding both RDF lang strings to the mix, but avoiding duplications
+                const frange = new Set([...raw.range, "rdf:langString", "rdf:dirLangString"]);
                 for (const term of frange) {
-                    range.push(factory.term(term))
+                    range.push(factory.term(term));
                 }
             } else {
                 for (const rg of raw.range) {
-                    if (rg.startsWith("xsd") === true || EXTRA_DATATYPES.find((entry) => entry === rg) !== undefined) {
+                    if (
+                        rg.startsWith("xsd") === true ||
+                        EXTRA_DATATYPES.find((entry) => entry === rg) !==
+                            undefined
+                    ) {
                         // The datatype is a simple one, not a class; a term nevertheless, to make it uniform
                         extra_types.push("owl:DatatypeProperty");
                         range.push(factory.term(rg));
@@ -387,10 +391,14 @@ export function getData(vocab_source: string): Vocab {
                                     extra_types.push("owl:DatatypeProperty");
                                     range.push(term);
                                 } else {
-                                    throw(new Error(`The range ${rg} of the property ${id} is neither a class nor a datatype, although defined in this vocabulary`));
+                                    throw new Error(
+                                        `The range ${rg} of the property ${id} is neither a class nor a datatype, although defined in this vocabulary`,
+                                    );
                                 }
                             } else {
-                                throw(new Error(`The range ${rg} of the property ${id} is not defined in this vocabulary`));
+                                throw new Error(
+                                    `The range ${rg} of the property ${id} is not defined in this vocabulary`,
+                                );
                             }
                         } else {
                             // By now, local classes and datatypes have been accounted for; the only remaining

--- a/lib/html.ts
+++ b/lib/html.ts
@@ -161,14 +161,18 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
             if (RDFTermFactory.isProperty(item)) {
                 if ((item as RDFProperty).strongURL) {
                     description += "<br><br>The property's value should be a URL, i.e., not a literal."
+                } else if((item as RDFProperty).langString) {
+                    description += "<br><br>The property's value should be a natural language string."
                 }
             }
             document.addChild(section, 'div', description);
-        } else if (RDFTermFactory.includesCurie(item.type, "owl:ObjectProperty")) {
-            if (RDFTermFactory.isProperty(item)) {
-                if ((item as RDFProperty).strongURL) {
+        } else {
+            if (RDFTermFactory.includesCurie(item.type, "owl:ObjectProperty")) {
+                if (RDFTermFactory.isProperty(item) && (item as RDFProperty).strongURL) {
                     document.addChild(section, 'p', "The property's value should be a URL, i.e., not a literal.");
                 }
+            } else if (RDFTermFactory.isProperty(item) && (item as RDFProperty).langString) {
+                document.addChild(section, 'p', "The property's value should be a natural language string.");
             }
         }
 

--- a/lib/html.ts
+++ b/lib/html.ts
@@ -272,7 +272,8 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
         if (head && basename !== '') {
             addLink(head, 'jsonld', 'application/ld+json');
             addLink(head, 'ttl', 'text/turtle');
-            if (context) addLink(head, 'context.jsonld','application/ld+json')
+            // This is a possibility, but it does not sound right. The context is not an alternate
+            // if (context) addLink(head, 'context.jsonld','application/ld+json')
         }
 
         // Handle the alternate 'a' links, if any of them are

--- a/lib/html.ts
+++ b/lib/html.ts
@@ -162,7 +162,7 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
                 if ((item as RDFProperty).strongURL) {
                     description += "<br><br>The property's value should be a URL, i.e., not a literal."
                 } else if((item as RDFProperty).langString) {
-                    description += "<br><br>The property's value should be a natural language string."
+                    description += "<br><br>The property's value is expected to be a natural language string.";
                 }
             }
             document.addChild(section, 'div', description);
@@ -172,7 +172,7 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
                     document.addChild(section, 'p', "The property's value should be a URL, i.e., not a literal.");
                 }
             } else if (RDFTermFactory.isProperty(item) && (item as RDFProperty).langString) {
-                document.addChild(section, 'p', "The property's value should be a natural language string.");
+                document.addChild(section, 'p', "The property's value is expected to be a natural language string.");
             }
         }
 

--- a/lib/html.ts
+++ b/lib/html.ts
@@ -272,12 +272,14 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
         if (head && basename !== '') {
             addLink(head, 'jsonld', 'application/ld+json');
             addLink(head, 'ttl', 'text/turtle');
+            if (context) addLink(head, 'context.jsonld','application/ld+json')
         }
 
         // Handle the alternate 'a' links, if any of them are
         // present in the template
         addAref('alt-turtle', 'ttl');
         addAref('alt-jsonld', 'jsonld');
+        if (context) addAref('alt-context','context.jsonld');
 
         // Hide this code here because it is related: removes an unnecessary
         // RDFa link from the body if it is there.

--- a/main.ts
+++ b/main.ts
@@ -30,6 +30,7 @@ async function main() {
         .option('-v --vocab [vocab]', 'vocabulary file name, defaults to "vocabulary.yml"')
         .option('-t --template [template]', 'template file name, defaults to "template.html"')
         .option('-c --context', 'whether a JSON-LD context file should also be generated, defaults to "false"')
+        .option('-d --debug', 'run in debug mode, full error stack is displayed if an error occurs, defaults to "false"')
         .parse(process.argv);
 
     const options = program.opts();
@@ -37,7 +38,8 @@ async function main() {
     const vocabulary: string = options.vocab ? options.vocab : 'vocabulary.yml';
     const template: string   = options.template ? options.template : 'template.html';
     const context: boolean   = !!options.context;
-    await yml2vocab.generateVocabularyFiles(vocabulary, template, context);
+    const debug: boolean     = !!options.debug;
+    await yml2vocab.generateVocabularyFiles(vocabulary, template, context, debug);
 }
 
 // At some point, node.js will allow to have async calls at the top level, and this extra function will

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yml2vocab",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "description": "Generation of vocabulary files starting by YAML",
     "homepage": "https://github.com/w3c/yml2vocab",
     "repository": {


### PR DESCRIPTION
## Version 1.8.2

### Functional changes

- If applicable, the reference to the generated context file is, if requested via an appropriate ID in the template, added to the HTML content.
- [Bug, sort of] Using `@import` in the generated json-ld context turned out to be brittle. Changed the context to an array, with the generated portion preceded by the list of "imported" context files (if applicable).
- Special actions when the `rdf:langString` or `rdf:dirLangString` are part of the range:
    - both are added to the range (if necessary) as a future-proof feature eyeing towards RDF 1.2
    - if these types are part of an array of range references, and the `range_union` flag is not set to `true`, an error is raised, because that is the only way these can work in practice
    - in the generated context the property should only have an `id` (i.e., no datatype is added, even if it is combined with `xsd:string`); otherwise the language/directions tags will be ignored

### Minor changes

- Improved the error reporting 
- Lots of minor, mostly editorial changes 
- As usual, documentation/README improvements
