### PR TITLE
add more required prefixes

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -482,5 +482,5 @@ export const defaultPrefixes: RDFPrefix[] = [
  * specificities of a particular serialization. These should not be filtered out
  * when optimizing the prefixes...
  */
-export const requiredTurtlePrefixes: string[] = ["vs", "owl", "rdf"];
-export const requiredJsonPrefixes: string[] = ["vs", "jsonld", "owl"];
+export const requiredTurtlePrefixes: string[] = ["vs", "owl", "rdf", "xsd", "jsonld", "schema"];
+export const requiredJsonPrefixes: string[] = ["vs", "jsonld", "owl", "xsd", "schema"];


### PR DESCRIPTION
*This PR adds prefixes to the list that will be always included in the generated Turtle and JSON-LD file (`xsd`, `schema`, and `jsonld` for Turtle). This ensures that the generated files are always correctly parsed.*

Strictly speaking, 'jsonld' and 'schema' are not *always* required in Turtle, only when a context is defined for the vocabulary. It might be cleaner to add them conditionally, but that's beyond my understanding of the code at the moment, so I'm going for the quick and dirty solution.

**edited**: added an intro paragraph clarifying what this PR does and why.