### PR TITLE
add an attribute `open_enumeration` for property descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,24 @@ class:
             <td>No</td>
         </tr>
         <tr>
+            <td><code>open_enumeration</code></td>
+            <td>boolean</td>
+            <td>
+                Only meaningful together with <code>one_of</code>. By default, the values listed in <code>one_of</code> are
+                turned into an anonymous class defined via <code>owl:oneOf</code>, i.e., a <em>closed</em> enumeration: the
+                property's range consists exclusively of the listed individuals. If <code>open_enumeration</code> is set to
+                <code>true</code>, the enumeration is treated as <em>open</em> instead: a fresh, named class is generated
+                (named after the property, with a <code>Range</code> suffix, e.g. <code>credentialStatus</code> gets a
+                <code>CredentialStatusRange</code> class) and used as the property's range, and the <code>one_of</code>
+                values are declared as instances of that class. Values not otherwise declared via an <code>individual</code>
+                block are automatically added as individuals of that class; external (CURIE-referenced) values are left
+                untouched, consistently with how external terms are handled elsewhere in this tool.
+                <br>This setting has no effect on the generated JSON-LD <code>@context</code>: the property is still mapped
+                the same way as for a closed enumeration.
+            </td>
+            <td>No</td>
+        </tr>
+        <tr>
             <td><code>range_union</code></td>
             <td>boolean</td>
             <td>
@@ -527,6 +545,14 @@ property:
       label: this is an example pr3
       one_of: [ex:val1, ex:val2, ex:val3]
       comment: Restricting the values to ex:val1, ex:val2, or ex:val3; in JSON-LD using the generated context "val1", "val2", "val3" should be used.
+
+    - id: pr4
+      label: this is an example pr4
+      one_of: [ex:val4, ex:val5]
+      open_enumeration: true
+      comment: >
+        The range is a fresh Pr4Range class, with ex:val4 and ex:val5 declared as its instances;
+        other, unlisted, values are also acceptable.
 ```
 
 #### 1.2.2.4. Individual definitions —`individual` Block

--- a/example/test.html
+++ b/example/test.html
@@ -1,199 +1,1301 @@
 <!DOCTYPE html>
-<html lang="en"><head>
+<html lang="en">
+
+<head>
     <meta charset="utf-8">
     <title>Security Vocabulary</title>
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <script>
-      function remove_status_remark() {
-          const sotd = document.getElementById("sotd");
-          const p = sotd.getElementsByTagName('p')[0];
-          sotd.removeChild(p);
-      }
+        function remove_status_remark() {
+            const sotd = document.getElementById("sotd");
+            const p = sotd.getElementsByTagName('p')[0];
+            sotd.removeChild(p);
+        }
+
     </script>
     <script class="remove">
-      var respecConfig = {
-        localBiblio: {
-        },
-        specStatus:  "base",
-        shortName:   "ns/security",
-        thisVersion: "https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html",
-        latestVersion: "https://w3id.org/security",
-        doJsonLd:    true,
-        editors: [{
-          name:       "Ivan Herman",
-          url:        "https://www.w3.org/People/Ivan/",
-          company:    "W3C",
-          w3cid:      7382,
-          orcid:      "0000-0003-0782-2704",
-          companyURL: "https://www.w3.org",
-        },{
-          name:       "Manu Sporny",
-          url:        "http://manu.sporny.org/",
-          company:    "Digital Bazaar",
-          companyURL: "http://digitalbazaar.com/",
-          w3cid:      41758,
-        },{
-          name:       "Dave Longley",
-          company:    "Digital Bazaar",
-          companyURL: "http://digitalbazaar.com/",
-          w3cid:      48025,
-        }],
-        // group : "vc",
-        // github: {
-				// 	repoURL: "https://github.com/w3c/vc-data-model",
-				// 	branch: "main"
-				// },
-        alternateFormats: [
-          {uri: "vocabulary.ttl", label: "Turtle"},
-          {uri: "vocabulary.jsonld", label: "JSON-LD"}
-        ],
-        inlineCSS: true,
-        doRDFa: false,
-        noIDLIn: true,
-        noLegacyStyle: false
-      };
+        var respecConfig = {
+            localBiblio: {},
+            specStatus: "base",
+            shortName: "ns/security",
+            thisVersion: "https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html",
+            latestVersion: "https://w3id.org/security",
+            doJsonLd: true,
+            editors: [{
+                name: "Ivan Herman",
+                url: "https://www.w3.org/People/Ivan/",
+                company: "W3C",
+                w3cid: 7382,
+                orcid: "0000-0003-0782-2704",
+                companyURL: "https://www.w3.org",
+            }, {
+                name: "Manu Sporny",
+                url: "http://manu.sporny.org/",
+                company: "Digital Bazaar",
+                companyURL: "http://digitalbazaar.com/",
+                w3cid: 41758,
+            }, {
+                name: "Dave Longley",
+                company: "Digital Bazaar",
+                companyURL: "http://digitalbazaar.com/",
+                w3cid: 48025,
+            }],
+            // group : "vc",
+            // github: {
+            // 	repoURL: "https://github.com/w3c/vc-data-model",
+            // 	branch: "main"
+            // },
+            alternateFormats: [{
+                    uri: "vocabulary.ttl",
+                    label: "Turtle"
+                },
+                {
+                    uri: "vocabulary.jsonld",
+                    label: "JSON-LD"
+                }
+            ],
+            inlineCSS: true,
+            doRDFa: false,
+            noIDLIn: true,
+            noLegacyStyle: false
+        };
+
     </script>
     <style type="text/css">
-      dl.terms dt {
-        float: left;
-        clear: left;
-        width: 10vw;
-      }
+        dl.terms dt {
+            float: left;
+            clear: left;
+            width: 10vw;
+        }
 
-      dl.terms dd {
-        margin-left: 15vw;
-      }
+        dl.terms dd {
+            margin-left: 15vw;
+        }
 
-      dl.terms dd:after {
-          content: '';
-          display: block;
-          clear: both;
-          margin-bottom: 5px;
-      }
-      table.rdfs-definition td {
-        vertical-align: top;
-        margin-right: 2em;
-      }
-      .bold {
-        font-weight: bold;
-      }
-      /* code {
+        dl.terms dd:after {
+            content: '';
+            display: block;
+            clear: both;
+            margin-bottom: 5px;
+        }
+
+        table.rdfs-definition td {
+            vertical-align: top;
+            margin-right: 2em;
+        }
+
+        .bold {
+            font-weight: bold;
+        }
+
+        /* code {
         color: red;
       } */
 
-      .term_definitions section {
-        border-bottom-style: solid ;
-        border-bottom-width: 1px;
-        border-bottom-color: darkgrey;
-      }
+        .term_definitions section {
+            border-bottom-style: solid;
+            border-bottom-width: 1px;
+            border-bottom-color: darkgrey;
+        }
 
-      .annoy {
-        background: hsla(40,100%,50%,0.95);
-		    color: black;
-		    padding: .75em 1em;
-		    border: red;
-		    border-style: solid none;
-		    box-shadow: 0 2px 8px black;
-		    text-align: center;
-      }
+        .annoy {
+            background: hsla(40, 100%, 50%, 0.95);
+            color: black;
+            padding: .75em 1em;
+            border: red;
+            border-style: solid none;
+            box-shadow: 0 2px 8px black;
+            text-align: center;
+        }
 
     </style>
-  </head>
-  <body typeof="owl:Ontology" resource="https://w3id.org/security/v1" prefix="sec: https://w3id.org/security/v1 cred: https://w3.org/2018/credentials# dc: http://purl.org/dc/terms/ owl: http://www.w3.org/2002/07/owl# rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns# rdfs: http://www.w3.org/2000/01/rdf-schema# xsd: http://www.w3.org/2001/XMLSchema# vs: http://www.w3.org/2003/06/sw-vocab-status/ns# schema: http://schema.org/ jsonld: http://www.w3.org/ns/json-ld#">
+    <link href="example/test.jsonld" rel="alternate" type="application/ld+json">
+    <link href="example/test.ttl" rel="alternate" type="text/turtle">
+</head>
+
+<body>
     <section id="abstract">
-      <p>This document describes the <span property="dc:title" id="title">Security Vocabulary</span>, i.e.,
-         the <span property="dc:description" id="description">vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs 
-</span>.
-      </p>
-      <p>Alternate versions of the vocabulary definition exist in
-        <a rel="alternate" href="vocabulary.ttl">Turtle</a> and
-        <a rel="alternate" href="vocabulary.jsonld">JSON-LD</a>.
-      </p>
-      <dl>
-        <dt>Published:</dt><dd><time property="dc:date" id="time">2025-01-16</time></dd>
-        <dt>Version Info:</dt>
-        <dd>2.0</dd>
-        <dt id="see_also">See Also: <a href="https://www.w3.org/TR/vc-data-integrity/" property="rdfs:seeAlso">https://www.w3.org/TR/vc-data-integrity/</a></dt>
-       </dl>
+        <p>This document describes the <span property="dc:title" id="ontology_title">Security Vocabulary</span>, i.e.,
+            the <span property="dc:description" id="description">vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained
+                digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs
+            </span>.
+        </p>
+        <p>Alternate versions of the vocabulary definition exist in
+            <a rel="alternate" href="vocabulary.ttl">Turtle</a> and
+            <a rel="alternate" href="vocabulary.jsonld">JSON-LD</a>.
+        </p>
+        <dl>
+            <dt>Published:</dt>
+            <dd><time property="dc:date" id="time">2026-08-03</time></dd>
+            <dt>Version Info:</dt>
+            <dd>2.0</dd>
+            <dt id="see_also">See Also: <a href="https://www.w3.org/TR/vc-data-integrity/">https://www.w3.org/TR/vc-data-integrity/</a></dt>
+        </dl>
     </section>
     <section id="sotd">
-      <p>
-        Comments regarding this document are welcome. Please file issues
-        directly on <a href="https://github.com/w3c/vc-data-integrity/issues/">GitHub</a>, or send them to
-        <a href="mailto:public-vc-comments@w3.org">public-vc-comments@w3.org</a>
-        (<a href="mailto:public-vc-comments-request@w3.org?subject=subscribe">subscribe</a>,
-        <a href="https://lists.w3.org/Archives/Public/public-vc-comments/">archives</a>).
-      </p>
+        <p>
+            Comments regarding this document are welcome. Please file issues
+            directly on <a href="https://github.com/w3c/vc-data-integrity/issues/">GitHub</a>, or send them to
+            <a href="mailto:public-vc-comments@w3.org">public-vc-comments@w3.org</a>
+            (<a href="mailto:public-vc-comments-request@w3.org?subject=subscribe">subscribe</a>,
+            <a href="https://lists.w3.org/Archives/Public/public-vc-comments/">archives</a>).
+        </p>
     </section>
     <section>
-      <h2>Namespaces</h2>
-      <p>This specification makes use of the following namespaces:</p>
-      <dl class="terms" id="namespaces">
-      <dt><code>sec</code></dt><dd><code>https://w3id.org/security/v1</code></dd><dt><code>cred</code></dt><dd><code>https://w3.org/2018/credentials#</code></dd><dt><code>dc</code></dt><dd><code>http://purl.org/dc/terms/</code></dd><dt><code>owl</code></dt><dd><code>http://www.w3.org/2002/07/owl#</code></dd><dt><code>rdf</code></dt><dd><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></dd><dt><code>rdfs</code></dt><dd><code>http://www.w3.org/2000/01/rdf-schema#</code></dd><dt><code>xsd</code></dt><dd><code>http://www.w3.org/2001/XMLSchema#</code></dd><dt><code>vs</code></dt><dd><code>http://www.w3.org/2003/06/sw-vocab-status/ns#</code></dd><dt><code>schema</code></dt><dd><code>http://schema.org/</code></dd><dt><code>jsonld</code></dt><dd><code>http://www.w3.org/ns/json-ld#</code></dd></dl>
+        <h2>Namespaces</h2>
+        <p>This specification makes use of the following namespaces:</p>
+        <dl class="terms" id="namespaces">
+            <dt><code>sec</code></dt>
+            <dd><code>https://w3id.org/security/v1</code></dd>
+            <dt><code>cred</code></dt>
+            <dd><code>https://w3.org/2018/credentials#</code></dd>
+            <dt><code>dc</code></dt>
+            <dd><code>http://purl.org/dc/terms/</code></dd>
+            <dt><code>owl</code></dt>
+            <dd><code>http://www.w3.org/2002/07/owl#</code></dd>
+            <dt><code>rdf</code></dt>
+            <dd><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></dd>
+            <dt><code>rdfs</code></dt>
+            <dd><code>http://www.w3.org/2000/01/rdf-schema#</code></dd>
+            <dt><code>xsd</code></dt>
+            <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
+        </dl>
     </section>
 
     <section id="term_definitions">
-      <h1>Term definitions</h1>
+        <h1>Term definitions</h1>
 
-      <section id="class_definitions" class="term_definitions">
-        <h2>Class definitions</h2>
-      <p>The following are  class definitions in the <code>sec</code> namespace.</p><section resource="sec:Proof" typeof="rdfs:Class" id="Proof"><h4><code>Proof</code></h4><p><em>Digital proof</em></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a digital proof on serialized data. </div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Domain of:</dt><dd><a href="#domain"><code>domain</code></a>, <a href="#challenge"><code>challenge</code></a>, <a href="#proofPurpose"><code>proofPurpose</code></a>, <a href="#proofValue"><code>proofValue</code></a>, <a href="#challenge"><code>challenge</code></a>, <a href="#expirationDate"><code>expirationDate</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:VerificationMethod" typeof="rdfs:Class" id="VerificationMethod"><h4><code>VerificationMethod</code></h4><p><em>Verification method</em></p><div property="rdfs:comment" datatype="rdf:HTML">A Verification Method class can express different verification methods, such as cryptographic public keys, which can be used to authenticate or authorize interaction with the `controller` or associated parties. Verification methods might take many parameters.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range of:</dt><dd><a href="#verificationMethod"><code>verificationMethod</code></a>, <a href="#authentication"><code>authentication</code></a>, <a href="#assertionMethod"><code>assertionMethod</code></a>, <a href="#capabilityDelegation"><code>capabilityDelegation</code></a>, <a href="#capabilityInvocation"><code>capabilityInvocation</code></a>, <a href="#keyAgreement"><code>keyAgreement</code></a></dd><dt>Domain of:</dt><dd><a href="#controller"><code>controller</code></a>, <a href="#publicKeyMultibase"><code>publicKeyMultibase</code></a>, <a href="#publicKeyJwk"><code>publicKeyJwk</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:DataIntegrityProof" typeof="rdfs:Class" id="DataIntegrityProof"><h4><code>DataIntegrityProof</code></h4><p><em>A Data Integrity Proof</em></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity proof used to encode a variety of cryptographic suite proof encodings.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof" property="rdfs:seeAlso">vc-data-integrity</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></span></dd></dl><dl class="terms"><dt>Domain of:</dt><dd><a href="#cryptosuite"><code>cryptosuite</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Ed25519Signature2020" typeof="rdfs:Class" id="Ed25519Signature2020"><h4><code>Ed25519Signature2020</code></h4><p><em>ED2559 Signature Suite, 2020 version</em></p><div property="rdfs:comment" datatype="rdf:HTML">T.B.D.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-  
-      <section id="property_definitions" class="term_definitions">
-        <h2>Property definitions</h2>
-      <p>The following are  property definitions in the <code>sec</code> namespace.</p><section resource="sec:verificationMethod" typeof="rdf:Property" id="verificationMethod"><h4><code>verificationMethod</code></h4><p><em>Verification method</em></p><div property="rdfs:comment" datatype="rdf:HTML">A `verificationMethod` property is used to specify a URL that contains information used for proof verification.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.w3.org/TR/did-core/#verification-methods" property="rdfs:seeAlso">Decentralized Identifiers (DIDs) v1.0</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:domain" typeof="rdf:Property owl:DatatypeProperty" id="domain"><h4><code>domain</code></h4><p><em>Domain of a proof</em></p><div property="rdfs:comment" datatype="rdf:HTML">The `domain` property is used to associate a domain with a proof, for use with a `proofPurpose` such as `authentication` and indicating its intended usage.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:challenge" typeof="rdf:Property owl:DatatypeProperty" id="challenge"><h4><code>challenge</code></h4><p><em>Challenge with a proof</em></p><div property="rdfs:comment" datatype="rdf:HTML">The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:proofPurpose" typeof="rdf:Property owl:DatatypeProperty" id="proofPurpose"><h4><code>proofPurpose</code></h4><p><em>Proof purpose</em></p><div property="rdfs:comment" datatype="rdf:HTML">The` proofPurpose` property is used to associate a purpose, such as `assertionMethod` or `authentication` with a proof. The proof purpose acts as a safeguard to prevent the proof from being misused by being applied to a purpose other than the one that was intended.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:proofValue" typeof="rdf:Property owl:DatatypeProperty" id="proofValue"><h4><code>proofValue</code></h4><p><em>Proof value</em></p><div property="rdfs:comment" datatype="rdf:HTML">A string value that contains the data necessary to verify the digital proof using the `verificationMethod` specified</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:proof" typeof="rdf:Property" id="proof"><h4><code>proof</code></h4><p><em>Proof sets</em></p><div property="rdfs:comment" datatype="rdf:HTML">The value of the `proof` property MUST identify <a href="”#ProofGraph”">`ProofGraph` instances</a> (informally, it indirectly identifies <a href="”#Proof”">`Proof` instances</a>, each contained in a separate graph). The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graphs that are then digested and digitally signed. The order of the proofs is not relevant.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:ProofGraph"><a href="#ProofGraph"><code>ProofGraph</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:proofChain" typeof="rdf:Property" id="proofChain"><h4><code>proofChain</code></h4><p><em>Proof chain</em></p><div property="rdfs:comment" datatype="rdf:HTML">The value of the `proofChain` property MUST identify a sequence of <a href="”#ProofGraph”">`ProofGraph` instances</a> (informally, it indirectly identifies a series of <a href="”#Proof”">`Proof` instances</a>, each contained in a separate graph). The property is used to provide a sequence of multiple proofs where the order of when the proofs occurred matters. The proof chain property is typically not included in the canonicalized graphs that are then separately digested and digitally signed.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="rdf:List"><code>rdf:List</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:controller" typeof="rdf:Property owl:ObjectProperty" id="controller"><h4><code>controller</code></h4><p><em>Controller</em></p><div property="rdfs:comment" datatype="rdf:HTML">A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship, where the controller claims control over a particular resource, and the resource clearly identifies its controller.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:authentication" typeof="rdf:Property" id="authentication"><h4><code>authentication</code></h4><p><em>Authentication method</em></p><div property="rdfs:comment" datatype="rdf:HTML">An `authentication` property is used to specify a URL that contains information about a `verificationMethod` used for authentication.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:assertionMethod" typeof="rdf:Property" id="assertionMethod"><h4><code>assertionMethod</code></h4><p><em>Assertion method</em></p><div property="rdfs:comment" datatype="rdf:HTML">An `assertionMethod` property is used to specify a URL that contains information about a `verificationMethod` used for assertions.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:capabilityDelegation" typeof="rdf:Property" id="capabilityDelegation"><h4><code>capabilityDelegation</code></h4><p><em>Capability Delegation Method</em></p><div property="rdfs:comment" datatype="rdf:HTML"><p>A `capabilityDelegation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of delegating capabilities.</p>
-<p>A `verificationMethod` may be referenced by its identifier (a URL) or expressed in full.</p>
-<p>The aforementioned proofs are created to prove that some entity is delegating the authority to take some action to another entity. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityDelegation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that has a property of `capabilityDelegation` that references the `verificationMethod`. This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:capabilityInvocation" typeof="rdf:Property" id="capabilityInvocation"><h4><code>capabilityInvocation</code></h4><p><em>Capability Invocation Method</em></p><div property="rdfs:comment" datatype="rdf:HTML"><p>A `capabilityInvocation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of invoking capabilities.</p>
-<p>A `verificationMethod` MAY be referenced by its identifier (a URL) or expressed in full.</p>
-<p>The aforementioned proofs are created to prove that some entity is attempting to exercise some authority they possess to take an action. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityInvocation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that, when dereferenced, has a property of `capabilityInvocation` that references the `verificationMethod.` This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:keyAgreement" typeof="rdf:Property" id="keyAgreement"><h4><code>keyAgreement</code></h4><p><em>Key agreement protocols</em></p><div property="rdfs:comment" datatype="rdf:HTML">Indicates that a proof is used for for key agreement protocols, such as Elliptic Curve Diffie Hellman key agreement used by popular encryption libraries.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:cryptosuite" typeof="rdf:Property owl:DatatypeProperty" id="cryptosuite"><h4><code>cryptosuite</code></h4><p><em>Cryptographic suite</em></p><div property="rdfs:comment" datatype="rdf:HTML">A text-based identifier for a specific cryptographic suite.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof" property="rdfs:seeAlso">vc-data-integrity</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:DataIntegrityProof"><a href="#DataIntegrityProof"><code>DataIntegrityProof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyMultibase" typeof="rdf:Property owl:DatatypeProperty" id="publicKeyMultibase"><h4><code>publicKeyMultibase</code></h4><p><em>Public key multibase</em></p><div property="rdfs:comment" datatype="rdf:HTML">The public key multibase property is used to specify the multibase-encoded version of a public key. The contents of the property are defined by specifications such as ED25519-2020 and listed in the Linked Data Cryptosuite Registry. Most public key type definitions are expected to:
-<ul>
-<li>Specify only a single encoding base per public key type as it reduces implementation burden and increases the chances of reaching broad interoperability.
-</li><li>Specify a multicodec header on the encoded public key to aid encoding and decoding applications in confirming that they are serializing and deserializing an expected public key type.
-</li><li>Use compressed binary formats to ensure efficient key sizes.
-</li></ul></div><dl class="terms"><dt>See also:</dt><dd><a href="https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03" property="rdfs:seeAlso">multibase</a><br><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/" property="rdfs:seeAlso">ld-cryptosuite-registry</a><br><a href="https://github.com/multiformats/multicodec/blob/master/table.csv" property="rdfs:seeAlso">multicodec</a><br><a href="https://w3c-ccg.github.io/lds-ed25519-2020/" property="rdfs:seeAlso">ed25519-2020</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyJwk" typeof="rdf:Property owl:DatatypeProperty" id="publicKeyJwk"><h4><code>publicKeyJwk</code></h4><p><em>Public key JWK</em></p><div property="rdfs:comment" datatype="rdf:HTML">See the JOSE suite.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.iana.org/assignments/jose/jose.xhtml" property="rdfs:seeAlso">IANA JOSE</a><br><a href="https://tools.ietf.org/html/rfc7517" property="rdfs:seeAlso">RFC 7517</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:VerificationMethod"><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-  
-      <section id="individual_definitions" class="term_definitions">
-        <h2>Definitions for individuals</h2>
-      <p>The following are definitions for  individuals in the <code>sec</code> namespace.</p><section resource="sec:SomeIndividual" typeof="cred:ABCD" id="SomeIndividual"><h4><code>SomeIndividual</code></h4><p><em>Testing the individuals</em></p><div property="rdfs:comment" datatype="rdf:HTML">A longer description for this individual</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.example.org/namivan/" property="rdfs:seeAlso">the description</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">stable</span><dl class="terms"><dt>Type</dt><dd><span><a href="https://w3.org/2018/credentials#ABCD"><code>cred:ABCD</code></a></span><br></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-    </section>   
-    
+        <section id="class_definitions" class="term_definitions">
+            <h2>Class definitions</h2>
+            <p>The following are class definitions in the <code>sec</code> namespace.</p>
+            <section id="Proof">
+                <h4><code>Proof</code></h4>
+                <p><em>Digital proof</em></p>
+                <div>This class represents a digital proof on serialized data. </div>
+                <dl class="terms">
+                    <dt>Domain of:</dt>
+                    <dd><a href="#domain"><code>domain</code></a>, <a href="#challenge"><code>challenge</code></a>, <a href="#proofPurpose"><code>proofPurpose</code></a>, <a
+                            href="#proofValue"><code>proofValue</code></a>, <a href="#challenge"><code>challenge</code></a>, <a
+                            href="#expirationDate"><code>expirationDate</code></a></dd>
+                </dl>
+            </section>
+            <section id="VerificationMethod">
+                <h4><code>VerificationMethod</code></h4>
+                <p><em>Verification method</em></p>
+                <div>A Verification Method class can express different verification methods, such as cryptographic public keys, which can be used to authenticate or authorize
+                    interaction with the `controller` or associated parties. Verification methods might take many parameters.</div>
+                <dl class="terms">
+                    <dt>Range of:</dt>
+                    <dd><a href="#verificationMethod"><code>verificationMethod</code></a>, <a href="#authentication"><code>authentication</code></a>, <a
+                            href="#assertionMethod"><code>assertionMethod</code></a>, <a href="#capabilityDelegation"><code>capabilityDelegation</code></a>, <a
+                            href="#capabilityInvocation"><code>capabilityInvocation</code></a>, <a href="#keyAgreement"><code>keyAgreement</code></a></dd>
+                    <dt>Domain of:</dt>
+                    <dd><a href="#publicKeyMultibase"><code>publicKeyMultibase</code></a>, <a href="#publicKeyJwk"><code>publicKeyJwk</code></a></dd>
+                </dl>
+            </section>
+            <section id="DataIntegrityProof">
+                <h4><code>DataIntegrityProof</code></h4>
+                <p><em>A Data Integrity Proof</em></p>
+                <div>This class represents a data integrity proof used to encode a variety of cryptographic suite proof encodings.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof">vc-data-integrity</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain of:</dt>
+                    <dd><a href="#cryptosuite"><code>cryptosuite</code></a></dd>
+                </dl>
+            </section>
+            <section id="Ed25519Signature2020">
+                <h4><code>Ed25519Signature2020</code></h4>
+                <p><em>ED2559 Signature Suite, 2020 version</em></p>
+                <div>T.B.D.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                </dl>
+            </section>
+            <section id="CredentialStatusRange">
+                <h4><code>CredentialStatusRange</code></h4>
+                <p><em>Credential status range</em></p>
+                <div>The range of possible values for the <code>sec:credentialStatus</code> property. This is an open enumeration: values beyond the ones listed here may also be
+                    valid.</div>
+                <dl class="terms">
+                    <dt>Range of:</dt>
+                    <dd><a href="#credentialStatus"><code>credentialStatus</code></a></dd>
+                </dl>
+            </section>
+        </section>
+
+        <section id="property_definitions" class="term_definitions">
+            <h2>Property definitions</h2>
+            <p>The following are property definitions in the <code>sec</code> namespace.</p>
+            <section id="credentialStatus">
+                <h4><code>credentialStatus</code></h4>
+                <p><em>Credential status</em></p>
+                <div>The status of the credential, restricted to a known, but extensible, set of values.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#CredentialStatusRange"><code>CredentialStatusRange</code></a></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Suggested values include:</dt>
+                    <dd><a href="#statusValid"><code>statusValid</code></a>, <a href="#statusRevoked"><code>statusRevoked</code></a></dd>
+                </dl>
+            </section>
+            <section id="verificationMethod">
+                <h4><code>verificationMethod</code></h4>
+                <p><em>Verification method</em></p>
+                <div>A `verificationMethod` property is used to specify a URL that contains information used for proof verification.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.w3.org/TR/did-core/#verification-methods">Decentralized Identifiers (DIDs) v1.0</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="domain">
+                <h4><code>domain</code></h4>
+                <p><em>Domain of a proof</em></p>
+                <div>The `domain` property is used to associate a domain with a proof, for use with a `proofPurpose` such as `authentication` and indicating its intended usage.
+                </div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="proofPurpose">
+                <h4><code>proofPurpose</code></h4>
+                <p><em>Proof purpose</em></p>
+                <div>The` proofPurpose` property is used to associate a purpose, such as `assertionMethod` or `authentication` with a proof. The proof purpose acts as a safeguard
+                    to prevent the proof from being misused by being applied to a purpose other than the one that was intended.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="proofValue">
+                <h4><code>proofValue</code></h4>
+                <p><em>Proof value</em></p>
+                <div>A string value that contains the data necessary to verify the digital proof using the `verificationMethod` specified</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="proof">
+                <h4><code>proof</code></h4>
+                <p><em>Proof sets</em></p>
+                <div>The value of the `proof` property MUST identify <a href="”#ProofGraph”">`ProofGraph` instances</a> (informally, it indirectly identifies <a
+                        href="”#Proof”">`Proof` instances</a>, each contained in a separate graph). The property is used to associate a proof with a graph of information. The proof
+                    property is typically not included in the canonicalized graphs that are then digested and digitally signed. The order of the proofs is not relevant.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#ProofGraph"><code>ProofGraph</code></a></dd>
+                </dl>
+            </section>
+            <section id="proofChain">
+                <h4><code>proofChain</code></h4>
+                <p><em>Proof chain</em></p>
+                <div>The value of the `proofChain` property MUST identify a sequence of <a href="”#ProofGraph”">`ProofGraph` instances</a> (informally, it indirectly identifies a
+                    series of <a href="”#Proof”">`Proof` instances</a>, each contained in a separate graph). The property is used to provide a sequence of multiple proofs where the
+                    order of when the proofs occurred matters. The proof chain property is typically not included in the canonicalized graphs that are then separately digested and
+                    digitally signed.</div>
+            </section>
+            <section id="authentication">
+                <h4><code>authentication</code></h4>
+                <p><em>Authentication method</em></p>
+                <div>An `authentication` property is used to specify a URL that contains information about a `verificationMethod` used for authentication.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="assertionMethod">
+                <h4><code>assertionMethod</code></h4>
+                <p><em>Assertion method</em></p>
+                <div>An `assertionMethod` property is used to specify a URL that contains information about a `verificationMethod` used for assertions.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="capabilityDelegation">
+                <h4><code>capabilityDelegation</code></h4>
+                <p><em>Capability Delegation Method</em></p>
+                <div>
+                    <p>A `capabilityDelegation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created
+                        for the purpose of delegating capabilities.</p>
+                    <p>A `verificationMethod` may be referenced by its identifier (a URL) or expressed in full.</p>
+                    <p>The aforementioned proofs are created to prove that some entity is delegating the authority to take some action to another entity. A verifier of the proof
+                        should expect the proof to express a `proofPurpose` of `capabilityDelegation` and reference a `verificationMethod` to verify it. The dereferenced
+                        `verificationMethod` MUST have a controller property that has a property of `capabilityDelegation` that references the `verificationMethod`. This indicates
+                        that the controller has authorized it for the expressed `proofPurpose`.</p>
+                </div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="capabilityInvocation">
+                <h4><code>capabilityInvocation</code></h4>
+                <p><em>Capability Invocation Method</em></p>
+                <div>
+                    <p>A `capabilityInvocation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created
+                        for the purpose of invoking capabilities.</p>
+                    <p>A `verificationMethod` MAY be referenced by its identifier (a URL) or expressed in full.</p>
+                    <p>The aforementioned proofs are created to prove that some entity is attempting to exercise some authority they possess to take an action. A verifier of the
+                        proof should expect the proof to express a `proofPurpose` of `capabilityInvocation` and reference a `verificationMethod` to verify it. The dereferenced
+                        `verificationMethod` MUST have a controller property that, when dereferenced, has a property of `capabilityInvocation` that references the
+                        `verificationMethod.` This indicates that the controller has authorized it for the expressed `proofPurpose`.</p>
+                </div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="keyAgreement">
+                <h4><code>keyAgreement</code></h4>
+                <p><em>Key agreement protocols</em></p>
+                <div>Indicates that a proof is used for for key agreement protocols, such as Elliptic Curve Diffie Hellman key agreement used by popular encryption libraries.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                </dl>
+            </section>
+            <section id="cryptosuite">
+                <h4><code>cryptosuite</code></h4>
+                <p><em>Cryptographic suite</em></p>
+                <div>A text-based identifier for a specific cryptographic suite.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof">vc-data-integrity</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#DataIntegrityProof"><code>DataIntegrityProof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKeyMultibase">
+                <h4><code>publicKeyMultibase</code></h4>
+                <p><em>Public key multibase</em></p>
+                <div>The public key multibase property is used to specify the multibase-encoded version of a public key. The contents of the property are defined by specifications
+                    such as ED25519-2020 and listed in the Linked Data Cryptosuite Registry. Most public key type definitions are expected to:
+                    <ul>
+                        <li>Specify only a single encoding base per public key type as it reduces implementation burden and increases the chances of reaching broad
+                            interoperability.
+                        </li>
+                        <li>Specify a multicodec header on the encoded public key to aid encoding and decoding applications in confirming that they are serializing and
+                            deserializing an expected public key type.
+                        </li>
+                        <li>Use compressed binary formats to ensure efficient key sizes.
+                        </li>
+                    </ul>
+                </div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03">multibase</a><br><a
+                            href="https://w3c-ccg.github.io/ld-cryptosuite-registry/">ld-cryptosuite-registry</a><br><a
+                            href="https://github.com/multiformats/multicodec/blob/master/table.csv">multicodec</a><br><a
+                            href="https://w3c-ccg.github.io/lds-ed25519-2020/">ed25519-2020</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKeyJwk">
+                <h4><code>publicKeyJwk</code></h4>
+                <p><em>Public key JWK</em></p>
+                <div>See the JOSE suite.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.iana.org/assignments/jose/jose.xhtml">IANA JOSE</a><br><a href="https://tools.ietf.org/html/rfc7517">RFC 7517</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#VerificationMethod"><code>VerificationMethod</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+        </section>
+
+        <section id="individual_definitions" class="term_definitions">
+            <h2>Definitions for individuals</h2>
+            <p>The following are definitions for individuals in the <code>sec</code> namespace.</p>
+            <section id="SomeIndividual">
+                <h4><code>SomeIndividual</code></h4>
+                <p><em>Testing the individuals</em></p>
+                <div>A longer description for this individual</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.example.org/namivan/">the description</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Type</dt>
+                    <dd><span><a href="https://w3.org/2018/credentials#ABCD"><code>cred:ABCD</code></a></span><br></dd>
+                </dl>
+            </section>
+            <section id="statusValid">
+                <h4><code>statusValid</code></h4>
+                <p><em>Status valid</em></p>
+                <dl class="terms">
+                    <dt>Type</dt>
+                    <dd><span><a href="#CredentialStatusRange"><code>CredentialStatusRange</code></a></span><br></dd>
+                </dl>
+            </section>
+            <section id="statusRevoked">
+                <h4><code>statusRevoked</code></h4>
+                <p><em>Status revoked</em></p>
+                <dl class="terms">
+                    <dt>Type</dt>
+                    <dd><span><a href="#CredentialStatusRange"><code>CredentialStatusRange</code></a></span><br></dd>
+                </dl>
+            </section>
+        </section>
+    </section>
+
     <section id="reserved_term_definitions">
-      <h1>Reserved term definitions</h1>
+        <h1>Reserved term definitions</h1>
 
-      <p>All terms in this section are 
-        <a href="https://www.w3.org/TR/vc-data-model-2.0/#reserved-extension-points"><em><strong>reserved</strong></em></a>. 
-        Implementers may use these terms, but should expect them and/or their meanings to change during the process to normatively specify them. 
-        Implementers should not use these properties without a publicly disclosed specification describing their implementation.
-      </p>
+        <p>All terms in this section are
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#reserved-extension-points"><em><strong>reserved</strong></em></a>.
+            Implementers may use these terms, but should expect them and/or their meanings to change during the process to normatively specify them.
+            Implementers should not use these properties without a publicly disclosed specification describing their implementation.
+        </p>
 
-      <section id="reserved_class_definitions" class="term_definitions">
-        <h2>Reserved classes</h2>
-      <p>The following are <em><strong>reserved</strong></em> class definitions in the <code>sec</code> namespace.</p><section resource="sec:ProofGraph" typeof="rdfs:Class" id="ProofGraph"><h4><code>ProofGraph</code></h4><p><em>An RDF Graph for a digital proof</em><span class="bold"><em> (reserved)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">Instances of this class are RDF Graphs, where each of these graphs must include exactly one Proof.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">reserved</span><dl class="terms"><dt>Range of:</dt><dd><a href="#proof"><code>proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-  
-      
-  
-      
-    </section>   
+        <section id="reserved_class_definitions" class="term_definitions">
+            <h2>Reserved classes</h2>
+            <p>The following are <em><strong>reserved</strong></em> class definitions in the <code>sec</code> namespace.</p>
+            <section id="ProofGraph">
+                <h4><code>ProofGraph</code></h4>
+                <p><em>An RDF Graph for a digital proof</em><span class="bold"><em> (reserved)</em></span></p>
+                <div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Proof.</div>
+                <dl class="terms">
+                    <dt>Range of:</dt>
+                    <dd><a href="#proof"><code>proof</code></a></dd>
+                </dl>
+            </section>
+        </section>
+
+
+    </section>
 
     <section id="deprecated_term_definitions">
-      <h1>Deprecated term definitions</h1>
+        <h1>Deprecated term definitions</h1>
 
-      <p class="annoy">All terms in this section are <em><strong>deprecated</strong></em>, and are only kept in this vocabulary for backward compatibility. 
-        <br><br>New applications should not use them.
-      </p>
+        <p class="annoy">All terms in this section are <em><strong>deprecated</strong></em>, and are only kept in this vocabulary for backward compatibility.
+            <br><br>New applications should not use them.
+        </p>
 
-      <section id="deprecated_class_definitions" class="term_definitions">
-        <h2>Deprecated classes</h2>
-      <p>The following are <em><strong>deprecated</strong></em> class definitions in the <code>sec</code> namespace.</p><section resource="sec:Key" typeof="rdfs:Class owl:DeprecatedClass" id="Key"><h4><code>Key</code></h4><p><em>Cryptographic key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain of:</dt><dd><a href="#privateKeyPem"><code>privateKeyPem</code></a>, <a href="#publicKey"><code>publicKey</code></a>, <a href="#publicKeyBase58"><code>publicKeyBase58</code></a>, <a href="#publicKeyPem"><code>publicKeyPem</code></a>, <a href="#publicKeyHex"><code>publicKeyHex</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Signature" typeof="rdfs:Class owl:DeprecatedClass" id="Signature"><h4><code>Signature</code></h4><p><em>Digital signature</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a digital signature on serialized data. It is an abstract class and should not be used other than for Semantic Web reasoning purposes, such as by a reasoning agent. This class MUST NOT be used directly, but only through its subclasses.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></span></dd></dl><dl class="terms"><dt>Range of:</dt><dd><a href="#jws"><code>jws</code></a>, <a href="#signature"><code>signature</code></a>, <a href="#x509CertificateChain"><code>x509CertificateChain</code></a>, <a href="#x509CertificateFingerprint"><code>x509CertificateFingerprint</code></a></dd><dt>Domain of:</dt><dd><a href="#nonce"><code>nonce</code></a>, <a href="#canonicalizationAlgorithm"><code>canonicalizationAlgorithm</code></a>, <a href="#signatureValue"><code>signatureValue</code></a>, <a href="#signatureAlgorithm"><code>signatureAlgorithm</code></a>, <a href="#service"><code>service</code></a>, <a href="#serviceEndpoint"><code>serviceEndpoint</code></a>, <a href="#x509CertificateChain"><code>x509CertificateChain</code></a>, <a href="#x509CertificateFingerprint"><code>x509CertificateFingerprint</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:SignatureGraph" typeof="rdfs:Class owl:DeprecatedClass" id="SignatureGraph"><h4><code>SignatureGraph</code></h4><p><em>An RDF Graph for a digital signature</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">Instances of this class are RDF Graphs, where each of these graphs must include exactly one Signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:ProofGraph"><a href="#ProofGraph"><code>ProofGraph</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EcdsaSecp256k1Signature2019" typeof="rdfs:Class owl:DeprecatedClass" id="EcdsaSecp256k1Signature2019"><h4><code>EcdsaSecp256k1Signature2019</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature suite.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1" property="rdfs:seeAlso">ecdsa-sep256k1</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EcdsaSecp256k1Signature2020" typeof="rdfs:Class owl:DeprecatedClass" id="EcdsaSecp256k1Signature2020"><h4><code>EcdsaSecp256k1Signature2020</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature suite.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1" property="rdfs:seeAlso">ecdsa-sep256k1</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EcdsaSecp256k1RecoverySignature2020" typeof="rdfs:Class owl:DeprecatedClass" id="EcdsaSecp256k1RecoverySignature2020"><h4><code>EcdsaSecp256k1RecoverySignature2020</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverysignature2020" property="rdfs:seeAlso">ecdsasecp256k1recoverysignature2020</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EcdsaSecp256k1VerificationKey2019" typeof="rdfs:Class owl:DeprecatedClass" id="EcdsaSecp256k1VerificationKey2019"><h4><code>EcdsaSecp256k1VerificationKey2019</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity verification method.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1" property="rdfs:seeAlso">ecdsa-secp256k1</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EcdsaSecp256k1RecoveryMethod2020" typeof="rdfs:Class owl:DeprecatedClass" id="EcdsaSecp256k1RecoveryMethod2020"><h4><code>EcdsaSecp256k1RecoveryMethod2020</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity verification method.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverymethod2020" property="rdfs:seeAlso">ecdsasecp256k1recoverymethod2020</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:RsaSignature2018" typeof="rdfs:Class owl:DeprecatedClass" id="RsaSignature2018"><h4><code>RsaSignature2018</code></h4><p><em>Signature Suite for RSA (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature suite.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa" property="rdfs:seeAlso">RSA registry entry</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:RsaVerificationKey2018" typeof="rdfs:Class owl:DeprecatedClass" id="RsaVerificationKey2018"><h4><code>RsaVerificationKey2018</code></h4><p><em>Verification Key for RSA (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity verification method.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa" property="rdfs:seeAlso">RSA registry entry</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:SchnorrSecp256k1Signature2019" typeof="rdfs:Class owl:DeprecatedClass" id="SchnorrSecp256k1Signature2019"><h4><code>SchnorrSecp256k1Signature2019</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature suite.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:SchnorrSecp256k1VerificationKey2019" typeof="rdfs:Class owl:DeprecatedClass" id="SchnorrSecp256k1VerificationKey2019"><h4><code>SchnorrSecp256k1VerificationKey2019</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity verification method.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:ServiceEndpointProxyService" typeof="rdfs:Class owl:DeprecatedClass" id="ServiceEndpointProxyService"><h4><code>ServiceEndpointProxyService</code></h4><p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">T.B.D.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Digest" typeof="rdfs:Class owl:DeprecatedClass" id="Digest"><h4><code>Digest</code></h4><p><em>Message digest</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a message digest that may be used for data integrity verification. The digest algorithm used will determine the cryptographic properties of the digest.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:EncryptedMessage" typeof="rdfs:Class owl:DeprecatedClass" id="EncryptedMessage"><h4><code>EncryptedMessage</code></h4><p><em>Encrypted message</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A class of messages that are obfuscated in some cryptographic manner. These messages are incredibly difficult to decrypt without the proper decryption key.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain of:</dt><dd><a href="#cipherAlgorithm"><code>cipherAlgorithm</code></a>, <a href="#cipherData"><code>cipherData</code></a>, <a href="#cipherKey"><code>cipherKey</code></a>, <a href="#initializationVector"><code>initializationVector</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:GraphSignature2012" typeof="rdfs:Class owl:DeprecatedClass" id="GraphSignature2012"><h4><code>GraphSignature2012</code></h4><p><em>RDF graph signature</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:LinkedDataSignature2015" typeof="rdfs:Class owl:DeprecatedClass" id="LinkedDataSignature2015"><h4><code>LinkedDataSignature2015</code></h4><p><em>Linked data signature, 2015 version (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:LinkedDataSignature2016" typeof="rdfs:Class owl:DeprecatedClass" id="LinkedDataSignature2016"><h4><code>LinkedDataSignature2016</code></h4><p><em>Linked data signature, 2016 version (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:MerkleProof2019" typeof="rdfs:Class owl:DeprecatedClass" id="MerkleProof2019"><h4><code>MerkleProof2019</code></h4><p><em>Merkle Proof</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and ECDSA to perform the digital signature.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/lds-merkle-proof-2019/" property="rdfs:seeAlso">Merkle Proof 2019</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:X25519KeyAgreementKey2019" typeof="rdfs:Class owl:DeprecatedClass" id="X25519KeyAgreementKey2019"><h4><code>X25519KeyAgreementKey2019</code></h4><p><em>X25519 Key Agreement Key 2019</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a verification key.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Ed25519VerificationKey2018" typeof="rdfs:Class owl:DeprecatedClass" id="Ed25519VerificationKey2018"><h4><code>Ed25519VerificationKey2018</code></h4><p><em>ED2559 Verification Key, 2018 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity verification method.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519" property="rdfs:seeAlso">eddsa-ed25519 registry entry</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Ed25519VerificationKey2020" typeof="rdfs:Class owl:DeprecatedClass" id="Ed25519VerificationKey2020"><h4><code>Ed25519VerificationKey2020</code></h4><p><em>ED2559 Verification Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A linked data proof suite verification method type used with <a href="”#Ed25519Signature2020">`Ed25519Signature2020`</a>.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:JsonWebKey2020" typeof="rdfs:Class owl:DeprecatedClass" id="JsonWebKey2020"><h4><code>JsonWebKey2020</code></h4><p><em>JSON Web Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A linked data proof suite verification method type used with <a href="”#JsonWebSignature2020">`JsonWebSignature2020`</a></div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:JsonWebSignature2020" typeof="rdfs:Class owl:DeprecatedClass" id="JsonWebSignature2020"><h4><code>JsonWebSignature2020</code></h4><p><em>JSON Web Signature, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and JWS to perform the digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:BbsBlsSignature2020" typeof="rdfs:Class owl:DeprecatedClass" id="BbsBlsSignature2020"><h4><code>BbsBlsSignature2020</code></h4><p><em>BBS Signature, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignature` digests each of the statements produced by the normalization process individually to enable selective disclosure. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:BbsBlsSignatureProof2020" typeof="rdfs:Class owl:DeprecatedClass" id="BbsBlsSignatureProof2020"><h4><code>BbsBlsSignatureProof2020</code></h4><p><em>BBS Signature Proof, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignatureProof2020` is in fact a proof of knowledge of an unrevealed BbsBlsSignature2020 enabling the ability to selectively reveal information from the set that was originally signed. Each of the statements produced by the normalizing process for a JSON-LD document featuring a <a href="”#BbsBlsSignatureProof2020&quot;">`BbsBlsSignatureProof2020`</a> represent statements that were originally signed in producing the `BbsBlsSignature2020` and represent the denomination under which information can be selectively disclosed. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Bls12381G1Key2020" typeof="rdfs:Class owl:DeprecatedClass" id="Bls12381G1Key2020"><h4><code>Bls12381G1Key2020</code></h4><p><em>BLS 12381 G1 Signature Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature key.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519" property="rdfs:seeAlso">eddsa-ed25519 registry entry</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:Bls12381G2Key2020" typeof="rdfs:Class owl:DeprecatedClass" id="Bls12381G2Key2020"><h4><code>Bls12381G2Key2020</code></h4><p><em>BLS 12381 G2 Signature Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This class represents a data integrity signature key.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519" property="rdfs:seeAlso">eddsa-ed25519 registry entry</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Subclass of:</dt><dd><span property="rdfs:subClassOf" resource="sec:Key"><a href="#Key"><code>Key</code></a></span></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-  
-      <section id="deprecated_property_definitions" class="term_definitions">
-        <h2>Deprecated properties</h2>
-      <p>The following are <em><strong>deprecated</strong></em> property definitions in the <code>sec</code> namespace.</p><section resource="sec:cipherAlgorithm" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="cipherAlgorithm"><h4><code>cipherAlgorithm</code></h4><p><em>Cipher algorithm</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The cipher algorithm describes the mechanism used to encrypt a message. It is typically a string expressing the cipher suite, the strength of the cipher, and a block cipher mode.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:EncryptedMessage"><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:cipherData" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="cipherData"><h4><code>cipherData</code></h4><p><em>Cipher data</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">Cipher data is an opaque blob of information that is used to specify an encrypted message.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:EncryptedMessage"><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:cipherKey" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="cipherKey"><h4><code>cipherKey</code></h4><p><em>Cipher key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A cipher key is a symmetric key that is used to encrypt or decrypt a piece of information. The key itself may be expressed in clear text or encrypted.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:EncryptedMessage"><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:digestAlgorithm" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="digestAlgorithm"><h4><code>digestAlgorithm</code></h4><p><em>Digest algorithm</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The digest algorithm is used to specify the cryptographic function to use when generating the data to be digitally signed. Typically, data that is to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step 2. A signature class typically specifies a default digest method, so this property is typically used to specify information for a signature algorithm.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:digestValue" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="digestValue"><h4><code>digestValue</code></h4><p><em>Digest value</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The digest value is used to express the output of the digest algorithm expressed in Base-16 (hexadecimal) format.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:blockchainAccountId" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="blockchainAccountId"><h4><code>blockchainAccountId</code></h4><p><em>Blockchain account ID</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A `blockchainAccountId` property is used to specify a blockchain account identifier, as per the <a href="”https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md”">CAIP-10Account ID Specification</a>.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:ethereumAddress" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="ethereumAddress"><h4><code>ethereumAddress</code></h4><p><em>Ethereum address</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An `ethereumAddress` property is used to specify the Ethereum address. As per the Ethereum Yellow Paper “Ethereum: a secure decentralised generalised transaction ledger” in consists of a prefix "0x", a common identifier for hexadecimal, concatenated with the rightmost 20 bytes of the Keccak-256 hash (big endian) of the ECDSA public key (the curve used is the so-called secp256k1). In hexadecimal, 2 digits represent a byte, meaning addresses contain 40 hexadecimal digits. The Ethereum address should also contain a checksum as per EIP-55.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://eips.ethereum.org/EIPS/eip-55" property="rdfs:seeAlso">EIP-55</a><br><a href="https://ethereum.github.io/yellowpaper/paper.pdf" property="rdfs:seeAlso">Ethereum Yellow Paper: Ethereum: a secure decentralised generalised transaction ledger</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:expires" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="expires"><h4><code>expires</code></h4><p><em>Expiration time</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The expiration time is typically associated with a <a href="”#Key">`Key`</a> and specifies when the validity of the key will expire.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:dateTime"><code>xsd:dateTime</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:initializationVector" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="initializationVector"><h4><code>initializationVector</code></h4><p><em>Initialization vector</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The initialization vector (IV) is a byte stream that is typically used to initialize certain block cipher encryption schemes. For a receiving application to be able to decrypt a message, it must know the decryption key and the initialization vector. The value is typically base-64 encoded.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:EncryptedMessage"><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:nonce" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="nonce"><h4><code>nonce</code></h4><p><em>Nonce</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:canonicalizationAlgorithm" typeof="rdf:Property owl:DeprecatedProperty" id="canonicalizationAlgorithm"><h4><code>canonicalizationAlgorithm</code></h4><p><em>Canonicalization algorithm</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so on the same set of information in a deterministic manner.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:controller" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="controller"><h4><code>controller</code></h4><p><em>Controller</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller claims control over a particular resource, and the resource clearly identifies its controller.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:owner" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="owner"><h4><code>owner</code></h4><p><em>Owner (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An owner is an entity that claims control over a particular resource. Note that ownership is best validated as a two-way relationship where the owner claims ownership over a particular resource, and the resource clearly identifies its owner.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:password" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="password"><h4><code>password</code></h4><p><em>Password</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A secret that is used to generate a key that can be used to encrypt or decrypt message. It is typically a string value.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:privateKeyPem" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="privateKeyPem"><h4><code>privateKeyPem</code></h4><p><em>PEM encoded private key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing private keys.</div><dl class="terms"><dt>See also:</dt><dd><a href="http://en.wikipedia.org/wiki/Privacy_Enhanced_Mail" property="rdfs:seeAlso">Privacy Enhanced Mail</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Key"><a href="#Key"><code>Key</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKey" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="publicKey"><h4><code>publicKey</code></h4><p><em>Public Key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A public key property is used to specify a URL that contains information about a public key.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Key"><a href="#Key"><code>Key</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyBase58" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="publicKeyBase58"><h4><code>publicKeyBase58</code></h4><p><em>Base58-encoded Public Key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A public key Base58 property is used to specify the base58-encoded version of the public key.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Key"><a href="#Key"><code>Key</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyPem" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="publicKeyPem"><h4><code>publicKeyPem</code></h4><p><em>Public key PEM</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions initializing public keys.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Key"><a href="#Key"><code>Key</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyHex" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="publicKeyHex"><h4><code>publicKeyHex</code></h4><p><em>Hex-encoded version of public Key</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A `publicKeyHex` property is used to specify the hex-encoded version of the public key, based on section 8 of rfc4648. Hex encoding is also known as Base16 encoding.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://tools.ietf.org/html/rfc4648#section-8" property="rdfs:seeAlso">rfc4648</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Key"><a href="#Key"><code>Key</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:publicKeyService" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="publicKeyService"><h4><code>publicKeyService</code></h4><p><em>Public key service</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The publicKeyService property is used to express the REST URL that provides public key management services.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:revoked" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="revoked"><h4><code>revoked</code></h4><p><em>Revocation time</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The revocation time is typically associated with a <a href="”#Key”">`Key`</a> that has been marked as invalid as of the date and time associated with the property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation schedules.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:dateTime"><code>xsd:dateTime</code></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:jws" typeof="rdf:Property owl:DeprecatedProperty" id="jws"><h4><code>jws</code></h4><p><em>Json Web Signature</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The jws property is used to associate a detached Json Web Signature with a proof.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://tools.ietf.org/html/rfc7797" property="rdfs:seeAlso">Detached JSON Web Signature</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:challenge" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="challenge"><h4><code>challenge</code></h4><p><em>Challenge with a proof</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:expirationDate" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="expirationDate"><h4><code>expirationDate</code></h4><p><em>Expiration date for proof</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The `expirationDate` property is used to associate an expiration date with a proof.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:dateTime"><code>xsd:dateTime</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Proof"><a href="#Proof"><code>Proof</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:signature" typeof="rdf:Property owl:DeprecatedProperty" id="signature"><h4><code>signature</code></h4><p><em>Signature  (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graph that is then digested, and digitally signed.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:signatureValue" typeof="rdf:Property owl:DeprecatedProperty owl:DatatypeProperty" id="signatureValue"><h4><code>signatureValue</code></h4><p><em>Signature value  (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The signature value is used to express the output of the signature algorithm expressed in base-64 format.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="xsd:string"><code>xsd:string</code></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:signatureAlgorithm" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="signatureAlgorithm"><h4><code>signatureAlgorithm</code></h4><p><em>Signature algorithm  (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital signatures.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:service" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="service"><h4><code>service</code></h4><p><em>Service</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:serviceEndpoint" typeof="rdf:Property owl:DeprecatedProperty owl:ObjectProperty" id="serviceEndpoint"><h4><code>serviceEndpoint</code></h4><p><em>Service endpoint</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A network address at which a service operates on behalf of a controller. Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services. Service endpoints might also be provided by a generalized data interchange protocol, such as extensible data interchange.<br><br>The property's value should be a URL, i.e., not a literal.</div><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:x509CertificateChain" typeof="rdf:Property owl:DeprecatedProperty" id="x509CertificateChain"><h4><code>x509CertificateChain</code></h4><p><em>X509 Certificate chain</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The x509CertificateChain property is used to associate a chain of X.509 Certificates with a proof. The value of this property is an ordered list where each value in the list is an X.509 Certificate expressed as a DER PKIX format, that is encoded with multibase using the base64pad variant. The certificate directly associated to the verification method used to verify the proof MUST be the first element in the list. Subsequent certificates in the list MAY be included where each one MUST certify the previous one.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://tools.ietf.org/html/rfc5280" property="rdfs:seeAlso">X.509 Certificates</a><br><a href="https://tools.ietf.org/id/draft-multiformats-multibase-00.html" property="rdfs:seeAlso">multibase</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:x509CertificateFingerprint" typeof="rdf:Property owl:DeprecatedProperty" id="x509CertificateFingerprint"><h4><code>x509CertificateFingerprint</code></h4><p><em>X509 Certificate fingerprint</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">The x509CertificateFingerprint property is used to associate an X.509 Certificate with a proof via its fingerprint. The value is a multihash encoded then multibase encoded value using the base64pad variant. It is RECOMMENDED that the fingerprint value be the SHA-256 hash of the X.509 Certificate.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://tools.ietf.org/html/rfc5280" property="rdfs:seeAlso">X.509 Certificates</a><br><a href="https://tools.ietf.org/id/draft-multiformats-multibase-00.html" property="rdfs:seeAlso">multibase</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Range:</dt><dd property="rdfs:range" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd><dt>Domain:</dt><dd property="rdfs:domain" resource="sec:Signature"><a href="#Signature"><code>Signature</code></a></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:allowedAction" typeof="rdf:Property owl:DeprecatedProperty" id="allowedAction"><h4><code>allowedAction</code></h4><p><em>Allowed action</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An action that the controller of a capability may take when invoking the capability.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegated-capability" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:capabilityChain" typeof="rdf:Property owl:DeprecatedProperty" id="capabilityChain"><h4><code>capabilityChain</code></h4><p><em>Capability chain</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An list of delegated capabilities from a delegator to a delegatee.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegation" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:capabilityAction" typeof="rdf:Property owl:DeprecatedProperty" id="capabilityAction"><h4><code>capabilityAction</code></h4><p><em>Capability action</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An action that can be taken given a capability.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#invoking-root-capability" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:caveat" typeof="rdf:Property owl:DeprecatedProperty" id="caveat"><h4><code>caveat</code></h4><p><em>Caveat</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A restriction on the way the capability may be used.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#caveats" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:delegator" typeof="rdf:Property owl:DeprecatedProperty" id="delegator"><h4><code>delegator</code></h4><p><em>Delegator</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An entity that delegates a capability to a delegatee.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegation" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:invocationTarget" typeof="rdf:Property owl:DeprecatedProperty" id="invocationTarget"><h4><code>invocationTarget</code></h4><p><em>Invocation target</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An invocation target identifies where a capability may be invoked, and identifies the target object for which the root capability expresses authority.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#root-capability" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section><section resource="sec:invoker" typeof="rdf:Property owl:DeprecatedProperty" id="invoker"><h4><code>invoker</code></h4><p><em>Invoker</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">An identifier to cryptographic material that can invoke a capability.</div><dl class="terms"><dt>See also:</dt><dd><a href="https://w3c-ccg.github.io/zcap-spec/#invocation" property="rdfs:seeAlso">Authorization Capabilities</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-  
-      <section id="deprecated_individual_definitions" class="term_definitions">
-        <h2>Deprecated individuals</h2>
-      <p>The following are definitions for <em><strong>deprecated</strong></em> individuals in the <code>sec</code> namespace.</p><section resource="sec:DeprecatedIndividual" typeof="cred:XYXX" id="DeprecatedIndividual"><h4><code>DeprecatedIndividual</code></h4><p><em>Testing the deprecated individuals</em><span class="bold"><em> (deprecated)</em></span></p><div property="rdfs:comment" datatype="rdf:HTML">A longer description for this deprecated individual</div><dl class="terms"><dt>See also:</dt><dd><a href="https://www.example.org/namivan/deprecated" property="rdfs:seeAlso">the description</a><br></dd></dl><span property="rdfs:isDefinedBy" resource="sec:"></span><span style="display: none" property="vs:term_status">deprecated</span><span property="owl:deprecated" datatype="xsd:boolean" style="display: none">true</span><dl class="terms"><dt>Type</dt><dd><span><a href="https://w3.org/2018/credentials#XYXX"><code>cred:XYXX</code></a></span><br></dd></dl><dl class="terms"><dt>Relevant <code>@context</code>:</dt><dd><span rev="schema:mentions"><a href="vocab"><code>vocab</code></a></span></dd></dl></section></section>
-    </section>   
-  
+        <section id="deprecated_class_definitions" class="term_definitions">
+            <h2>Deprecated classes</h2>
+            <p>The following are <em><strong>deprecated</strong></em> class definitions in the <code>sec</code> namespace.</p>
+            <section id="Key">
+                <h4><code>Key</code></h4>
+                <p><em>Cryptographic key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data.</div>
+                <dl class="terms">
+                    <dt>Domain of:</dt>
+                    <dd><a href="#privateKeyPem"><code>privateKeyPem</code></a>, <a href="#publicKey"><code>publicKey</code></a>, <a
+                            href="#publicKeyBase58"><code>publicKeyBase58</code></a>, <a href="#publicKeyPem"><code>publicKeyPem</code></a>, <a
+                            href="#publicKeyHex"><code>publicKeyHex</code></a></dd>
+                </dl>
+            </section>
+            <section id="Signature">
+                <h4><code>Signature</code></h4>
+                <p><em>Digital signature</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a digital signature on serialized data. It is an abstract class and should not be used other than for Semantic Web reasoning purposes,
+                    such as by a reasoning agent. This class MUST NOT be used directly, but only through its subclasses.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Range of:</dt>
+                    <dd><a href="#jws"><code>jws</code></a>, <a href="#signature"><code>signature</code></a>, <a href="#x509CertificateChain"><code>x509CertificateChain</code></a>,
+                        <a href="#x509CertificateFingerprint"><code>x509CertificateFingerprint</code></a></dd>
+                    <dt>Domain of:</dt>
+                    <dd><a href="#nonce"><code>nonce</code></a>, <a href="#canonicalizationAlgorithm"><code>canonicalizationAlgorithm</code></a>, <a
+                            href="#signatureValue"><code>signatureValue</code></a>, <a href="#signatureAlgorithm"><code>signatureAlgorithm</code></a>, <a
+                            href="#service"><code>service</code></a>, <a href="#serviceEndpoint"><code>serviceEndpoint</code></a>, <a
+                            href="#x509CertificateChain"><code>x509CertificateChain</code></a>, <a href="#x509CertificateFingerprint"><code>x509CertificateFingerprint</code></a>
+                    </dd>
+                </dl>
+            </section>
+            <section id="SignatureGraph">
+                <h4><code>SignatureGraph</code></h4>
+                <p><em>An RDF Graph for a digital signature</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#ProofGraph"><code>ProofGraph</code></a></dd>
+                </dl>
+            </section>
+            <section id="EcdsaSecp256k1Signature2019">
+                <h4><code>EcdsaSecp256k1Signature2019</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature suite.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1">ecdsa-sep256k1</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="EcdsaSecp256k1Signature2020">
+                <h4><code>EcdsaSecp256k1Signature2020</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature suite.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1">ecdsa-sep256k1</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="EcdsaSecp256k1RecoverySignature2020">
+                <h4><code>EcdsaSecp256k1RecoverySignature2020</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverysignature2020">ecdsasecp256k1recoverysignature2020</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="EcdsaSecp256k1VerificationKey2019">
+                <h4><code>EcdsaSecp256k1VerificationKey2019</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity verification method.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1">ecdsa-secp256k1</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="EcdsaSecp256k1RecoveryMethod2020">
+                <h4><code>EcdsaSecp256k1RecoveryMethod2020</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity verification method.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverymethod2020">ecdsasecp256k1recoverymethod2020</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="RsaSignature2018">
+                <h4><code>RsaSignature2018</code></h4>
+                <p><em>Signature Suite for RSA (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature suite.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa">RSA registry entry</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="RsaVerificationKey2018">
+                <h4><code>RsaVerificationKey2018</code></h4>
+                <p><em>Verification Key for RSA (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity verification method.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa">RSA registry entry</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="SchnorrSecp256k1Signature2019">
+                <h4><code>SchnorrSecp256k1Signature2019</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature suite.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="SchnorrSecp256k1VerificationKey2019">
+                <h4><code>SchnorrSecp256k1VerificationKey2019</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity verification method.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="ServiceEndpointProxyService">
+                <h4><code>ServiceEndpointProxyService</code></h4>
+                <p><em>TBD.</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>T.B.D.</div>
+            </section>
+            <section id="Digest">
+                <h4><code>Digest</code></h4>
+                <p><em>Message digest</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a message digest that may be used for data integrity verification. The digest algorithm used will determine the cryptographic properties
+                    of the digest.</div>
+            </section>
+            <section id="EncryptedMessage">
+                <h4><code>EncryptedMessage</code></h4>
+                <p><em>Encrypted message</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A class of messages that are obfuscated in some cryptographic manner. These messages are incredibly difficult to decrypt without the proper decryption key.
+                </div>
+                <dl class="terms">
+                    <dt>Domain of:</dt>
+                    <dd><a href="#cipherAlgorithm"><code>cipherAlgorithm</code></a>, <a href="#cipherData"><code>cipherData</code></a>, <a
+                            href="#cipherKey"><code>cipherKey</code></a>, <a href="#initializationVector"><code>initializationVector</code></a></dd>
+                </dl>
+            </section>
+            <section id="GraphSignature2012">
+                <h4><code>GraphSignature2012</code></h4>
+                <p><em>RDF graph signature</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization
+                    specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital
+                    signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="LinkedDataSignature2015">
+                <h4><code>LinkedDataSignature2015</code></h4>
+                <p><em>Linked data signature, 2015 version (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital
+                    signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="LinkedDataSignature2016">
+                <h4><code>LinkedDataSignature2016</code></h4>
+                <p><em>Linked data signature, 2016 version (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital
+                    signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="MerkleProof2019">
+                <h4><code>MerkleProof2019</code></h4>
+                <p><em>Merkle Proof</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and ECDSA to perform the
+                    digital signature.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/lds-merkle-proof-2019/">Merkle Proof 2019</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="X25519KeyAgreementKey2019">
+                <h4><code>X25519KeyAgreementKey2019</code></h4>
+                <p><em>X25519 Key Agreement Key 2019</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a verification key.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="Ed25519VerificationKey2018">
+                <h4><code>Ed25519VerificationKey2018</code></h4>
+                <p><em>ED2559 Verification Key, 2018 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity verification method.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519">eddsa-ed25519 registry entry</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="Ed25519VerificationKey2020">
+                <h4><code>Ed25519VerificationKey2020</code></h4>
+                <p><em>ED2559 Verification Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A linked data proof suite verification method type used with <a href="”#Ed25519Signature2020">`Ed25519Signature2020`</a>.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="JsonWebKey2020">
+                <h4><code>JsonWebKey2020</code></h4>
+                <p><em>JSON Web Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A linked data proof suite verification method type used with <a href="”#JsonWebSignature2020">`JsonWebSignature2020`</a></div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="JsonWebSignature2020">
+                <h4><code>JsonWebSignature2020</code></h4>
+                <p><em>JSON Web Signature, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and JWS to perform the digital signature.
+                </div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="BbsBlsSignature2020">
+                <h4><code>BbsBlsSignature2020</code></h4>
+                <p><em>BBS Signature, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignature` digests each of the statements produced by the normalization
+                    process individually to enable selective disclosure. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital
+                    signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="BbsBlsSignatureProof2020">
+                <h4><code>BbsBlsSignatureProof2020</code></h4>
+                <p><em>BBS Signature Proof, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization
+                    specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignatureProof2020` is in fact a proof of knowledge of an unrevealed
+                    BbsBlsSignature2020 enabling the ability to selectively reveal information from the set that was originally signed. Each of the statements produced by the
+                    normalizing process for a JSON-LD document featuring a <a href="”#BbsBlsSignatureProof2020&quot;">`BbsBlsSignatureProof2020`</a> represent statements that were
+                    originally signed in producing the `BbsBlsSignature2020` and represent the denomination under which information can be selectively disclosed. The signature
+                    mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="Bls12381G1Key2020">
+                <h4><code>Bls12381G1Key2020</code></h4>
+                <p><em>BLS 12381 G1 Signature Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature key.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519">eddsa-ed25519 registry entry</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="Bls12381G2Key2020">
+                <h4><code>Bls12381G2Key2020</code></h4>
+                <p><em>BLS 12381 G2 Signature Key, 2020 version</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This class represents a data integrity signature key.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519">eddsa-ed25519 registry entry</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Subclass of:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+        </section>
 
-</body></html>
+        <section id="deprecated_property_definitions" class="term_definitions">
+            <h2>Deprecated properties</h2>
+            <p>The following are <em><strong>deprecated</strong></em> property definitions in the <code>sec</code> namespace.</p>
+            <section id="challenge">
+                <h4><code>challenge</code></h4>
+                <p><em>Challenge with a proof</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be
+                    included in a proof if a `domain` is specified.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="controller">
+                <h4><code>controller</code></h4>
+                <p><em>Controller</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller
+                    claims control over a particular resource, and the resource clearly identifies its controller.<br><br>The property's value should be a URL, i.e., not a literal.
+                </div>
+            </section>
+            <section id="cipherAlgorithm">
+                <h4><code>cipherAlgorithm</code></h4>
+                <p><em>Cipher algorithm</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The cipher algorithm describes the mechanism used to encrypt a message. It is typically a string expressing the cipher suite, the strength of the cipher, and a
+                    block cipher mode.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="cipherData">
+                <h4><code>cipherData</code></h4>
+                <p><em>Cipher data</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>Cipher data is an opaque blob of information that is used to specify an encrypted message.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="cipherKey">
+                <h4><code>cipherKey</code></h4>
+                <p><em>Cipher key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A cipher key is a symmetric key that is used to encrypt or decrypt a piece of information. The key itself may be expressed in clear text or encrypted.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="digestAlgorithm">
+                <h4><code>digestAlgorithm</code></h4>
+                <p><em>Digest algorithm</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The digest algorithm is used to specify the cryptographic function to use when generating the data to be digitally signed. Typically, data that is to be signed
+                    goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step 2. A
+                    signature class typically specifies a default digest method, so this property is typically used to specify information for a signature algorithm.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="digestValue">
+                <h4><code>digestValue</code></h4>
+                <p><em>Digest value</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The digest value is used to express the output of the digest algorithm expressed in Base-16 (hexadecimal) format.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="blockchainAccountId">
+                <h4><code>blockchainAccountId</code></h4>
+                <p><em>Blockchain account ID</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A `blockchainAccountId` property is used to specify a blockchain account identifier, as per the <a
+                        href="”https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md”">CAIP-10Account ID Specification</a>.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="ethereumAddress">
+                <h4><code>ethereumAddress</code></h4>
+                <p><em>Ethereum address</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An `ethereumAddress` property is used to specify the Ethereum address. As per the Ethereum Yellow Paper “Ethereum: a secure decentralised generalised
+                    transaction ledger” in consists of a prefix "0x", a common identifier for hexadecimal, concatenated with the rightmost 20 bytes of the Keccak-256 hash (big
+                    endian) of the ECDSA public key (the curve used is the so-called secp256k1). In hexadecimal, 2 digits represent a byte, meaning addresses contain 40 hexadecimal
+                    digits. The Ethereum address should also contain a checksum as per EIP-55.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://eips.ethereum.org/EIPS/eip-55">EIP-55</a><br><a href="https://ethereum.github.io/yellowpaper/paper.pdf">Ethereum Yellow Paper: Ethereum: a
+                            secure decentralised generalised transaction ledger</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="expires">
+                <h4><code>expires</code></h4>
+                <p><em>Expiration time</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The expiration time is typically associated with a <a href="”#Key">`Key`</a> and specifies when the validity of the key will expire.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:dateTime</code></dd>
+                </dl>
+            </section>
+            <section id="initializationVector">
+                <h4><code>initializationVector</code></h4>
+                <p><em>Initialization vector</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The initialization vector (IV) is a byte stream that is typically used to initialize certain block cipher encryption schemes. For a receiving application to be
+                    able to decrypt a message, it must know the decryption key and the initialization vector. The value is typically base-64 encoded.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#EncryptedMessage"><code>EncryptedMessage</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="nonce">
+                <h4><code>nonce</code></h4>
+                <p><em>Nonce</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to
+                    track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a
+                    privileged request.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="canonicalizationAlgorithm">
+                <h4><code>canonicalizationAlgorithm</code></h4>
+                <p><em>Canonicalization algorithm</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then
+                    digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so
+                    on the same set of information in a deterministic manner.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="controller">
+                <h4><code>controller</code></h4>
+                <p><em>Controller</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller
+                    claims control over a particular resource, and the resource clearly identifies its controller.<br><br>The property's value should be a URL, i.e., not a literal.
+                </div>
+            </section>
+            <section id="owner">
+                <h4><code>owner</code></h4>
+                <p><em>Owner (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An owner is an entity that claims control over a particular resource. Note that ownership is best validated as a two-way relationship where the owner claims
+                    ownership over a particular resource, and the resource clearly identifies its owner.<br><br>The property's value should be a URL, i.e., not a literal.</div>
+            </section>
+            <section id="password">
+                <h4><code>password</code></h4>
+                <p><em>Password</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A secret that is used to generate a key that can be used to encrypt or decrypt message. It is typically a string value.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="privateKeyPem">
+                <h4><code>privateKeyPem</code></h4>
+                <p><em>PEM encoded private key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer
+                    library implementation and typically plugs directly into functions intializing private keys.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="http://en.wikipedia.org/wiki/Privacy_Enhanced_Mail">Privacy Enhanced Mail</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKey">
+                <h4><code>publicKey</code></h4>
+                <p><em>Public Key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A public key property is used to specify a URL that contains information about a public key.<br><br>The property's value should be a URL, i.e., not a literal.
+                </div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                </dl>
+            </section>
+            <section id="publicKeyBase58">
+                <h4><code>publicKeyBase58</code></h4>
+                <p><em>Base58-encoded Public Key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A public key Base58 property is used to specify the base58-encoded version of the public key.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKeyPem">
+                <h4><code>publicKeyPem</code></h4>
+                <p><em>Public key PEM</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer
+                    library implementation and typically plugs directly into functions initializing public keys.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKeyHex">
+                <h4><code>publicKeyHex</code></h4>
+                <p><em>Hex-encoded version of public Key</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A `publicKeyHex` property is used to specify the hex-encoded version of the public key, based on section 8 of rfc4648. Hex encoding is also known as Base16
+                    encoding.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://tools.ietf.org/html/rfc4648#section-8">rfc4648</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Key"><code>Key</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="publicKeyService">
+                <h4><code>publicKeyService</code></h4>
+                <p><em>Public key service</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The publicKeyService property is used to express the REST URL that provides public key management services.<br><br>The property's value should be a URL, i.e.,
+                    not a literal.</div>
+            </section>
+            <section id="revoked">
+                <h4><code>revoked</code></h4>
+                <p><em>Revocation time</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The revocation time is typically associated with a <a href="”#Key”">`Key`</a> that has been marked as invalid as of the date and time associated with the
+                    property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation
+                    schedules.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><code>xsd:dateTime</code></dd>
+                </dl>
+            </section>
+            <section id="jws">
+                <h4><code>jws</code></h4>
+                <p><em>Json Web Signature</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The jws property is used to associate a detached Json Web Signature with a proof.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://tools.ietf.org/html/rfc7797">Detached JSON Web Signature</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="challenge">
+                <h4><code>challenge</code></h4>
+                <p><em>Challenge with a proof</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be
+                    included in a proof if a `domain` is specified.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="expirationDate">
+                <h4><code>expirationDate</code></h4>
+                <p><em>Expiration date for proof</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The `expirationDate` property is used to associate an expiration date with a proof.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Proof"><code>Proof</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:dateTime</code></dd>
+                </dl>
+            </section>
+            <section id="signature">
+                <h4><code>signature</code></h4>
+                <p><em>Signature (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graph that is then
+                    digested, and digitally signed.</div>
+                <dl class="terms">
+                    <dt>Range:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="signatureValue">
+                <h4><code>signatureValue</code></h4>
+                <p><em>Signature value (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The signature value is used to express the output of the signature algorithm expressed in base-64 format.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><code>xsd:string</code></dd>
+                </dl>
+            </section>
+            <section id="signatureAlgorithm">
+                <h4><code>signatureAlgorithm</code></h4>
+                <p><em>Signature algorithm (was deprecated in the CCG document)</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed
+                    goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A
+                    signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital
+                    signatures.<br><br>The property's value should be a URL, i.e., not a literal.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="service">
+                <h4><code>service</code></h4>
+                <p><em>Service</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services.<br><br>The
+                    property's value should be a URL, i.e., not a literal.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="serviceEndpoint">
+                <h4><code>serviceEndpoint</code></h4>
+                <p><em>Service endpoint</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A network address at which a service operates on behalf of a controller. Examples of specific services include discovery services, social networks, file
+                    storage services, and verifiable claim repository services. Service endpoints might also be provided by a generalized data interchange protocol, such as
+                    extensible data interchange.<br><br>The property's value should be a URL, i.e., not a literal.</div>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="x509CertificateChain">
+                <h4><code>x509CertificateChain</code></h4>
+                <p><em>X509 Certificate chain</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The x509CertificateChain property is used to associate a chain of X.509 Certificates with a proof. The value of this property is an ordered list where each
+                    value in the list is an X.509 Certificate expressed as a DER PKIX format, that is encoded with multibase using the base64pad variant. The certificate directly
+                    associated to the verification method used to verify the proof MUST be the first element in the list. Subsequent certificates in the list MAY be included where
+                    each one MUST certify the previous one.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://tools.ietf.org/html/rfc5280">X.509 Certificates</a><br><a
+                            href="https://tools.ietf.org/id/draft-multiformats-multibase-00.html">multibase</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="x509CertificateFingerprint">
+                <h4><code>x509CertificateFingerprint</code></h4>
+                <p><em>X509 Certificate fingerprint</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>The x509CertificateFingerprint property is used to associate an X.509 Certificate with a proof via its fingerprint. The value is a multihash encoded then
+                    multibase encoded value using the base64pad variant. It is RECOMMENDED that the fingerprint value be the SHA-256 hash of the X.509 Certificate.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://tools.ietf.org/html/rfc5280">X.509 Certificates</a><br><a
+                            href="https://tools.ietf.org/id/draft-multiformats-multibase-00.html">multibase</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Domain:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                    <dt>Range:</dt>
+                    <dd><a href="#Signature"><code>Signature</code></a></dd>
+                </dl>
+            </section>
+            <section id="allowedAction">
+                <h4><code>allowedAction</code></h4>
+                <p><em>Allowed action</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An action that the controller of a capability may take when invoking the capability.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegated-capability">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="capabilityChain">
+                <h4><code>capabilityChain</code></h4>
+                <p><em>Capability chain</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An list of delegated capabilities from a delegator to a delegatee.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegation">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="capabilityAction">
+                <h4><code>capabilityAction</code></h4>
+                <p><em>Capability action</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An action that can be taken given a capability.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#invoking-root-capability">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="caveat">
+                <h4><code>caveat</code></h4>
+                <p><em>Caveat</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A restriction on the way the capability may be used.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#caveats">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="delegator">
+                <h4><code>delegator</code></h4>
+                <p><em>Delegator</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An entity that delegates a capability to a delegatee.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#delegation">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="invocationTarget">
+                <h4><code>invocationTarget</code></h4>
+                <p><em>Invocation target</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An invocation target identifies where a capability may be invoked, and identifies the target object for which the root capability expresses authority.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#root-capability">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+            <section id="invoker">
+                <h4><code>invoker</code></h4>
+                <p><em>Invoker</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>An identifier to cryptographic material that can invoke a capability.</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://w3c-ccg.github.io/zcap-spec/#invocation">Authorization Capabilities</a><br></dd>
+                </dl>
+            </section>
+        </section>
+
+        <section id="deprecated_individual_definitions" class="term_definitions">
+            <h2>Deprecated individuals</h2>
+            <p>The following are definitions for <em><strong>deprecated</strong></em> individuals in the <code>sec</code> namespace.</p>
+            <section id="DeprecatedIndividual">
+                <h4><code>DeprecatedIndividual</code></h4>
+                <p><em>Testing the deprecated individuals</em><span class="bold"><em> (deprecated)</em></span></p>
+                <div>A longer description for this deprecated individual</div>
+                <dl class="terms">
+                    <dt>See also:</dt>
+                    <dd><a href="https://www.example.org/namivan/deprecated">the description</a><br></dd>
+                </dl>
+                <dl class="terms">
+                    <dt>Type</dt>
+                    <dd><span><a href="https://w3.org/2018/credentials#XYXX"><code>cred:XYXX</code></a></span><br></dd>
+                </dl>
+            </section>
+        </section>
+    </section>
+
+
+</body>
+
+</html>

--- a/example/test.jsonld
+++ b/example/test.jsonld
@@ -28,11 +28,8 @@
         "rdfs:subPropertyOf": {
             "@type": "@id"
         },
-        "owl:equivalentClass": {
-            "@type": "@vocab"
-        },
-        "owl:equivalentProperty": {
-            "@type": "@vocab"
+        "rdfs:isDefinedBy": {
+            "@type": "@id"
         },
         "owl:oneOf": {
             "@container": "@list",
@@ -41,12 +38,6 @@
         "owl:deprecated": {
             "@type": "xsd:boolean"
         },
-        "owl:imports": {
-            "@type": "@id"
-        },
-        "owl:versionInfo": {
-            "@type": "@id"
-        },
         "owl:inverseOf": {
             "@type": "@vocab"
         },
@@ -54,2031 +45,1136 @@
             "@container": "@list",
             "@type": "@vocab"
         },
-        "rdfs_classes": {
-            "@reverse": "rdfs:isDefinedBy",
+        "mentions": {
+            "@id": "schema:mentions",
             "@type": "@id"
-        },
-        "rdfs_properties": {
-            "@reverse": "rdfs:isDefinedBy",
-            "@type": "@id"
-        },
-        "rdfs_instances": {
-            "@reverse": "rdfs:isDefinedBy",
-            "@type": "@id"
-        },
-        "rdfs_datatypes": {
-            "@reverse": "rdfs:isDefinedBy",
-            "@type": "@id"
-        },
-        "mentioned": {
-            "@reverse": "schema:mentions",
-            "@type": "@id"
-        },
+        }
+    },
+    "@included": [{
+        "@id": "https://w3id.org/security/v1",
+        "@type": "owl:Ontology",
         "dc:title": {
-            "@container": "@language"
+            "@value": "Security Vocabulary",
+            "@language": "en"
         },
         "dc:description": {
-            "@container": "@language"
-        }
-    },
-    "@id": "https://w3id.org/security/v1",
-    "@type": "owl:Ontology",
-    "dc:title": {
-        "@value": "Security Vocabulary",
-        "@language": "en"
-    },
-    "dc:description": {
-        "@value": "vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs \n",
-        "@language": "en"
-    },
-    "rdfs:seeAlso": "https://www.w3.org/TR/vc-data-integrity/",
-    "dc:date": "2025-01-16",
-    "rdfs_properties": [
-        {
-            "@id": "sec:verificationMethod",
-            "@type": "rdf:Property",
-            "rdfs:range": "sec:VerificationMethod",
-            "rdfs:label": "Verification method",
-            "rdfs:comment": {
-                "@value": "<div>A `verificationMethod` property is used to specify a URL that contains information used for proof verification.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://www.w3.org/TR/did-core/#verification-methods"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:domain",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Domain of a proof",
-            "rdfs:comment": {
-                "@value": "<div>The `domain` property is used to associate a domain with a proof, for use with a `proofPurpose` such as `authentication` and indicating its intended usage.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:challenge",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Challenge with a proof",
-            "rdfs:comment": {
-                "@value": "<div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:proofPurpose",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Proof purpose",
-            "rdfs:comment": {
-                "@value": "<div>The` proofPurpose` property is used to associate a purpose, such as `assertionMethod` or `authentication` with a proof. The proof purpose acts as a safeguard to prevent the proof from being misused by being applied to a purpose other than the one that was intended.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:proofValue",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Proof value",
-            "rdfs:comment": {
-                "@value": "<div>A string value that contains the data necessary to verify the digital proof using the `verificationMethod` specified</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:proof",
-            "@type": "rdf:Property",
-            "rdfs:range": "sec:ProofGraph",
-            "rdfs:label": "Proof sets",
-            "rdfs:comment": {
-                "@value": "<div>The value of the `proof` property MUST identify <a href=”#ProofGraph”>`ProofGraph` instances</a> (informally, it indirectly identifies <a href=”#Proof”>`Proof` instances</a>, each contained in a separate graph). The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graphs that are then digested and digitally signed. The order of the proofs is not relevant.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:proofChain",
-            "@type": "rdf:Property",
-            "rdfs:range": "rdf:List",
-            "rdfs:label": "Proof chain",
-            "rdfs:comment": {
-                "@value": "<div>The value of the `proofChain` property MUST identify a sequence of <a href=”#ProofGraph”>`ProofGraph` instances</a> (informally, it indirectly identifies a series of <a href=”#Proof”>`Proof` instances</a>, each contained in a separate graph). The property is used to provide a sequence of multiple proofs where the order of when the proofs occurred matters. The proof chain property is typically not included in the canonicalized graphs that are then separately digested and digitally signed.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:controller",
-            "@type": [
-                "rdf:Property",
-                "owl:ObjectProperty"
-            ],
-            "rdfs:domain": "sec:VerificationMethod",
-            "rdfs:label": "Controller",
-            "rdfs:comment": {
-                "@value": "<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship, where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:authentication",
-            "@type": "rdf:Property",
-            "rdfs:range": "VerificationMethod",
-            "rdfs:label": "Authentication method",
-            "rdfs:comment": {
-                "@value": "<div>An `authentication` property is used to specify a URL that contains information about a `verificationMethod` used for authentication.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:assertionMethod",
-            "@type": "rdf:Property",
-            "rdfs:range": "VerificationMethod",
-            "rdfs:label": "Assertion method",
-            "rdfs:comment": {
-                "@value": "<div>An `assertionMethod` property is used to specify a URL that contains information about a `verificationMethod` used for assertions.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:capabilityDelegation",
-            "@type": "rdf:Property",
-            "rdfs:range": "VerificationMethod",
-            "rdfs:label": "Capability Delegation Method",
-            "rdfs:comment": {
-                "@value": "<div><p>A `capabilityDelegation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of delegating capabilities.</p>\n<p>A `verificationMethod` may be referenced by its identifier (a URL) or expressed in full.</p>\n<p>The aforementioned proofs are created to prove that some entity is delegating the authority to take some action to another entity. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityDelegation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that has a property of `capabilityDelegation` that references the `verificationMethod`. This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:capabilityInvocation",
-            "@type": "rdf:Property",
-            "rdfs:range": "VerificationMethod",
-            "rdfs:label": "Capability Invocation Method",
-            "rdfs:comment": {
-                "@value": "<div><p>A `capabilityInvocation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of invoking capabilities.</p>\n<p>A `verificationMethod` MAY be referenced by its identifier (a URL) or expressed in full.</p>\n<p>The aforementioned proofs are created to prove that some entity is attempting to exercise some authority they possess to take an action. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityInvocation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that, when dereferenced, has a property of `capabilityInvocation` that references the `verificationMethod.` This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:keyAgreement",
-            "@type": "rdf:Property",
-            "rdfs:range": "VerificationMethod",
-            "rdfs:label": "Key agreement protocols",
-            "rdfs:comment": {
-                "@value": "<div>Indicates that a proof is used for for key agreement protocols, such as Elliptic Curve Diffie Hellman key agreement used by popular encryption libraries.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:cryptosuite",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:DataIntegrityProof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Cryptographic suite",
-            "rdfs:comment": {
-                "@value": "<div>A text-based identifier for a specific cryptographic suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyMultibase",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:VerificationMethod",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Public key multibase",
-            "rdfs:comment": {
-                "@value": "<div>The public key multibase property is used to specify the multibase-encoded version of a public key. The contents of the property are defined by specifications such as ED25519-2020 and listed in the Linked Data Cryptosuite Registry. Most public key type definitions are expected to:\n<ul>\n<li>Specify only a single encoding base per public key type as it reduces implementation burden and increases the chances of reaching broad interoperability.\n<li>Specify a multicodec header on the encoded public key to aid encoding and decoding applications in confirming that they are serializing and deserializing an expected public key type.\n<li>Use compressed binary formats to ensure efficient key sizes.\n</ul></div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03",
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/",
-                "https://github.com/multiformats/multicodec/blob/master/table.csv",
-                "https://w3c-ccg.github.io/lds-ed25519-2020/"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyJwk",
-            "@type": [
-                "rdf:Property",
-                "owl:DatatypeProperty"
-            ],
-            "rdfs:domain": "sec:VerificationMethod",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Public key JWK",
-            "rdfs:comment": {
-                "@value": "<div>See the JOSE suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://www.iana.org/assignments/jose/jose.xhtml",
-                "https://tools.ietf.org/html/rfc7517"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:cipherAlgorithm",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:EncryptedMessage",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Cipher algorithm",
-            "rdfs:comment": {
-                "@value": "<div>The cipher algorithm describes the mechanism used to encrypt a message. It is typically a string expressing the cipher suite, the strength of the cipher, and a block cipher mode.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:cipherData",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:EncryptedMessage",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Cipher data",
-            "rdfs:comment": {
-                "@value": "<div>Cipher data is an opaque blob of information that is used to specify an encrypted message.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:cipherKey",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:EncryptedMessage",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Cipher key",
-            "rdfs:comment": {
-                "@value": "<div>A cipher key is a symmetric key that is used to encrypt or decrypt a piece of information. The key itself may be expressed in clear text or encrypted.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:digestAlgorithm",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Digest algorithm",
-            "rdfs:comment": {
-                "@value": "<div>The digest algorithm is used to specify the cryptographic function to use when generating the data to be digitally signed. Typically, data that is to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step 2. A signature class typically specifies a default digest method, so this property is typically used to specify information for a signature algorithm.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:digestValue",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Digest value",
-            "rdfs:comment": {
-                "@value": "<div>The digest value is used to express the output of the digest algorithm expressed in Base-16 (hexadecimal) format.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:blockchainAccountId",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Blockchain account ID",
-            "rdfs:comment": {
-                "@value": "<div>A `blockchainAccountId` property is used to specify a blockchain account identifier, as per the <a href=”https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md”>CAIP-10Account ID Specification</a>.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:ethereumAddress",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Ethereum address",
-            "rdfs:comment": {
-                "@value": "<div>An `ethereumAddress` property is used to specify the Ethereum address. As per the Ethereum Yellow Paper “Ethereum: a secure decentralised generalised transaction ledger” in consists of a prefix \"0x\", a common identifier for hexadecimal, concatenated with the rightmost 20 bytes of the Keccak-256 hash (big endian) of the ECDSA public key (the curve used is the so-called secp256k1). In hexadecimal, 2 digits represent a byte, meaning addresses contain 40 hexadecimal digits. The Ethereum address should also contain a checksum as per EIP-55.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://eips.ethereum.org/EIPS/eip-55",
-                "https://ethereum.github.io/yellowpaper/paper.pdf"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:expires",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:dateTime",
-            "rdfs:label": "Expiration time",
-            "rdfs:comment": {
-                "@value": "<div>The expiration time is typically associated with a <a href=”#Key>`Key`</a> and specifies when the validity of the key will expire.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:initializationVector",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:EncryptedMessage",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Initialization vector",
-            "rdfs:comment": {
-                "@value": "<div>The initialization vector (IV) is a byte stream that is typically used to initialize certain block cipher encryption schemes. For a receiving application to be able to decrypt a message, it must know the decryption key and the initialization vector. The value is typically base-64 encoded.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:nonce",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Nonce",
-            "rdfs:comment": {
-                "@value": "<div>This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:canonicalizationAlgorithm",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:label": "Canonicalization algorithm",
-            "rdfs:comment": {
-                "@value": "<div>The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so on the same set of information in a deterministic manner.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:controller",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Controller",
-            "rdfs:comment": {
-                "@value": "<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:owner",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Owner (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>An owner is an entity that claims control over a particular resource. Note that ownership is best validated as a two-way relationship where the owner claims ownership over a particular resource, and the resource clearly identifies its owner.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:password",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Password",
-            "rdfs:comment": {
-                "@value": "<div>A secret that is used to generate a key that can be used to encrypt or decrypt message. It is typically a string value.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:privateKeyPem",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Key",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "PEM encoded private key",
-            "rdfs:comment": {
-                "@value": "<div>A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing private keys.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "http://en.wikipedia.org/wiki/Privacy_Enhanced_Mail"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKey",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Key",
-            "rdfs:label": "Public Key",
-            "rdfs:comment": {
-                "@value": "<div>A public key property is used to specify a URL that contains information about a public key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyBase58",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Key",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Base58-encoded Public Key",
-            "rdfs:comment": {
-                "@value": "<div>A public key Base58 property is used to specify the base58-encoded version of the public key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyPem",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Key",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Public key PEM",
-            "rdfs:comment": {
-                "@value": "<div>A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions initializing public keys.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyHex",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Key",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Hex-encoded version of public Key",
-            "rdfs:comment": {
-                "@value": "<div>A `publicKeyHex` property is used to specify the hex-encoded version of the public key, based on section 8 of rfc4648. Hex encoding is also known as Base16 encoding.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://tools.ietf.org/html/rfc4648#section-8"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:publicKeyService",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Public key service",
-            "rdfs:comment": {
-                "@value": "<div>The publicKeyService property is used to express the REST URL that provides public key management services.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:revoked",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "xsd:dateTime",
-            "rdfs:label": "Revocation time",
-            "rdfs:comment": {
-                "@value": "<div>The revocation time is typically associated with a <a href=”#Key”>`Key`</a> that has been marked as invalid as of the date and time associated with the property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation schedules.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:jws",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "sec:Signature",
-            "rdfs:label": "Json Web Signature",
-            "rdfs:comment": {
-                "@value": "<div>The jws property is used to associate a detached Json Web Signature with a proof.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://tools.ietf.org/html/rfc7797"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:challenge",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Challenge with a proof",
-            "rdfs:comment": {
-                "@value": "<div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:expirationDate",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Proof",
-            "rdfs:range": "xsd:dateTime",
-            "rdfs:label": "Expiration date for proof",
-            "rdfs:comment": {
-                "@value": "<div>The `expirationDate` property is used to associate an expiration date with a proof.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:signature",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:range": "sec:Signature",
-            "rdfs:label": "Signature  (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graph that is then digested, and digitally signed.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:signatureValue",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:DatatypeProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:range": "xsd:string",
-            "rdfs:label": "Signature value  (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>The signature value is used to express the output of the signature algorithm expressed in base-64 format.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:signatureAlgorithm",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:label": "Signature algorithm  (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital signatures.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:service",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:label": "Service",
-            "rdfs:comment": {
-                "@value": "<div>Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:serviceEndpoint",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty",
-                "owl:ObjectProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:label": "Service endpoint",
-            "rdfs:comment": {
-                "@value": "<div>A network address at which a service operates on behalf of a controller. Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services. Service endpoints might also be provided by a generalized data interchange protocol, such as extensible data interchange.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:x509CertificateChain",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:range": "sec:Signature",
-            "rdfs:label": "X509 Certificate chain",
-            "rdfs:comment": {
-                "@value": "<div>The x509CertificateChain property is used to associate a chain of X.509 Certificates with a proof. The value of this property is an ordered list where each value in the list is an X.509 Certificate expressed as a DER PKIX format, that is encoded with multibase using the base64pad variant. The certificate directly associated to the verification method used to verify the proof MUST be the first element in the list. Subsequent certificates in the list MAY be included where each one MUST certify the previous one.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://tools.ietf.org/html/rfc5280",
-                "https://tools.ietf.org/id/draft-multiformats-multibase-00.html"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:x509CertificateFingerprint",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:domain": "sec:Signature",
-            "rdfs:range": "sec:Signature",
-            "rdfs:label": "X509 Certificate fingerprint",
-            "rdfs:comment": {
-                "@value": "<div>The x509CertificateFingerprint property is used to associate an X.509 Certificate with a proof via its fingerprint. The value is a multihash encoded then multibase encoded value using the base64pad variant. It is RECOMMENDED that the fingerprint value be the SHA-256 hash of the X.509 Certificate.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://tools.ietf.org/html/rfc5280",
-                "https://tools.ietf.org/id/draft-multiformats-multibase-00.html"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:allowedAction",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Allowed action",
-            "rdfs:comment": {
-                "@value": "<div>An action that the controller of a capability may take when invoking the capability.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#delegated-capability"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:capabilityChain",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Capability chain",
-            "rdfs:comment": {
-                "@value": "<div>An list of delegated capabilities from a delegator to a delegatee.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#delegation"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:capabilityAction",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Capability action",
-            "rdfs:comment": {
-                "@value": "<div>An action that can be taken given a capability.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#invoking-root-capability"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:caveat",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Caveat",
-            "rdfs:comment": {
-                "@value": "<div>A restriction on the way the capability may be used.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#caveats"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:delegator",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Delegator",
-            "rdfs:comment": {
-                "@value": "<div>An entity that delegates a capability to a delegatee.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#delegation"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:invocationTarget",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Invocation target",
-            "rdfs:comment": {
-                "@value": "<div>An invocation target identifies where a capability may be invoked, and identifies the target object for which the root capability expresses authority.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#root-capability"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:invoker",
-            "@type": [
-                "rdf:Property",
-                "owl:DeprecatedProperty"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Invoker",
-            "rdfs:comment": {
-                "@value": "<div>An identifier to cryptographic material that can invoke a capability.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/zcap-spec/#invocation"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        }
-    ],
-    "rdfs_classes": [
-        {
-            "@id": "sec:Proof",
-            "@type": "rdfs:Class",
-            "rdfs:label": "Digital proof",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a digital proof on serialized data. </div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:ProofGraph",
-            "@type": "rdfs:Class",
-            "rdfs:label": "An RDF Graph for a digital proof",
-            "rdfs:comment": {
-                "@value": "<div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Proof.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "reserved",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:VerificationMethod",
-            "@type": "rdfs:Class",
-            "rdfs:label": "Verification method",
-            "rdfs:comment": {
-                "@value": "<div>A Verification Method class can express different verification methods, such as cryptographic public keys, which can be used to authenticate or authorize interaction with the `controller` or associated parties. Verification methods might take many parameters.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:DataIntegrityProof",
-            "@type": "rdfs:Class",
-            "rdfs:subClassOf": [
-                "sec:Proof"
-            ],
-            "rdfs:label": "A Data Integrity Proof",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity proof used to encode a variety of cryptographic suite proof encodings.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Ed25519Signature2020",
-            "@type": "rdfs:Class",
-            "rdfs:subClassOf": [
-                "sec:Proof"
-            ],
-            "rdfs:label": "ED2559 Signature Suite, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>T.B.D.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Key",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Cryptographic key",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Signature",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Proof"
-            ],
-            "rdfs:label": "Digital signature",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a digital signature on serialized data. It is an abstract class and should not be used other than for Semantic Web reasoning purposes, such as by a reasoning agent. This class MUST NOT be used directly, but only through its subclasses.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:SignatureGraph",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:ProofGraph"
-            ],
-            "rdfs:label": "An RDF Graph for a digital signature",
-            "rdfs:comment": {
-                "@value": "<div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EcdsaSecp256k1Signature2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EcdsaSecp256k1Signature2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EcdsaSecp256k1RecoverySignature2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverysignature2020"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EcdsaSecp256k1VerificationKey2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity verification method.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EcdsaSecp256k1RecoveryMethod2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity verification method.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverymethod2020"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:RsaSignature2018",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "Signature Suite for RSA (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:RsaVerificationKey2018",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "Verification Key for RSA (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity verification method.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:SchnorrSecp256k1Signature2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature suite.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:SchnorrSecp256k1VerificationKey2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity verification method.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:ServiceEndpointProxyService",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "TBD.",
-            "rdfs:comment": {
-                "@value": "<div>T.B.D.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Digest",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Message digest",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a message digest that may be used for data integrity verification. The digest algorithm used will determine the cryptographic properties of the digest.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:EncryptedMessage",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:label": "Encrypted message",
-            "rdfs:comment": {
-                "@value": "<div>A class of messages that are obfuscated in some cryptographic manner. These messages are incredibly difficult to decrypt without the proper decryption key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:GraphSignature2012",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "RDF graph signature",
-            "rdfs:comment": {
-                "@value": "<div>A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:LinkedDataSignature2015",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "Linked data signature, 2015 version (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:LinkedDataSignature2016",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "Linked data signature, 2016 version (was deprecated in the CCG document)",
-            "rdfs:comment": {
-                "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:MerkleProof2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "Merkle Proof",
-            "rdfs:comment": {
-                "@value": "<div>Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and ECDSA to perform the digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/lds-merkle-proof-2019/"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:X25519KeyAgreementKey2019",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "X25519 Key Agreement Key 2019",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a verification key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Ed25519VerificationKey2018",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "ED2559 Verification Key, 2018 version",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity verification method.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Ed25519VerificationKey2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "ED2559 Verification Key, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>A linked data proof suite verification method type used with <a href=”#Ed25519Signature2020>`Ed25519Signature2020`</a>.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:JsonWebKey2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "JSON Web Key, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>A linked data proof suite verification method type used with <a href=”#JsonWebSignature2020>`JsonWebSignature2020`</a></div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:JsonWebSignature2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "JSON Web Signature, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and JWS to perform the digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:BbsBlsSignature2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "BBS Signature, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignature` digests each of the statements produced by the normalization process individually to enable selective disclosure. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:BbsBlsSignatureProof2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Signature"
-            ],
-            "rdfs:label": "BBS Signature Proof, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignatureProof2020` is in fact a proof of knowledge of an unrevealed BbsBlsSignature2020 enabling the ability to selectively reveal information from the set that was originally signed. Each of the statements produced by the normalizing process for a JSON-LD document featuring a <a href=”#BbsBlsSignatureProof2020\">`BbsBlsSignatureProof2020`</a> represent statements that were originally signed in producing the `BbsBlsSignature2020` and represent the denomination under which information can be selectively disclosed. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Bls12381G1Key2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "BLS 12381 G1 Signature Key, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:Bls12381G2Key2020",
-            "@type": [
-                "rdfs:Class",
-                "owl:DeprecatedClass"
-            ],
-            "owl:deprecated": true,
-            "rdfs:subClassOf": [
-                "sec:Key"
-            ],
-            "rdfs:label": "BLS 12381 G2 Signature Key, 2020 version",
-            "rdfs:comment": {
-                "@value": "<div>This class represents a data integrity signature key.</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        }
-    ],
-    "rdfs_individuals": [
-        {
-            "@id": "sec:SomeIndividual",
-            "@type": "cred:ABCD",
-            "rdfs:label": "Testing the individuals",
-            "rdfs:comment": {
-                "@value": "<div>A longer description for this individual</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "stable",
-            "rdfs:seeAlso": [
-                "https://www.example.org/namivan/"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        },
-        {
-            "@id": "sec:DeprecatedIndividual",
-            "@type": "cred:XYXX",
-            "owl:deprecated": true,
-            "rdfs:label": "Testing the deprecated individuals",
-            "rdfs:comment": {
-                "@value": "<div>A longer description for this deprecated individual</div>",
-                "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
-            },
-            "vs:term_status": "deprecated",
-            "rdfs:seeAlso": [
-                "https://www.example.org/namivan/deprecated"
-            ],
-            "mentioned": [
-                {
-                    "@id": "vocab",
-                    "@type": "jsonld:Context"
-                }
-            ]
-        }
-    ]
+            "@value": "vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs \n",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:seeAlso": "https://www.w3.org/TR/vc-data-integrity/",
+        "dc:date": "2026-08-03"
+    }, {
+        "@id": "sec:credentialStatus",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:CredentialStatusRange",
+        "rdfs:label": "Credential status",
+        "rdfs:comment": {
+            "@value": "<div>The status of the credential, restricted to a known, but extensible, set of values.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:verificationMethod",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Verification method",
+        "rdfs:comment": {
+            "@value": "<div>A `verificationMethod` property is used to specify a URL that contains information used for proof verification.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://www.w3.org/TR/did-core/#verification-methods"]
+    }, {
+        "@id": "sec:domain",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Domain of a proof",
+        "rdfs:comment": {
+            "@value": "<div>The `domain` property is used to associate a domain with a proof, for use with a `proofPurpose` such as `authentication` and indicating its intended usage.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:challenge",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Challenge with a proof",
+        "rdfs:comment": {
+            "@value": "<div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:proofPurpose",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Proof purpose",
+        "rdfs:comment": {
+            "@value": "<div>The` proofPurpose` property is used to associate a purpose, such as `assertionMethod` or `authentication` with a proof. The proof purpose acts as a safeguard to prevent the proof from being misused by being applied to a purpose other than the one that was intended.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:proofValue",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Proof value",
+        "rdfs:comment": {
+            "@value": "<div>A string value that contains the data necessary to verify the digital proof using the `verificationMethod` specified</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:proof",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:ProofGraph",
+        "rdfs:label": "Proof sets",
+        "rdfs:comment": {
+            "@value": "<div>The value of the `proof` property MUST identify <a href=”#ProofGraph”>`ProofGraph` instances</a> (informally, it indirectly identifies <a href=”#Proof”>`Proof` instances</a>, each contained in a separate graph). The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graphs that are then digested and digitally signed. The order of the proofs is not relevant.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:proofChain",
+        "@type": "rdf:Property",
+        "rdfs:range": "rdf:List",
+        "rdfs:label": "Proof chain",
+        "rdfs:comment": {
+            "@value": "<div>The value of the `proofChain` property MUST identify a sequence of <a href=”#ProofGraph”>`ProofGraph` instances</a> (informally, it indirectly identifies a series of <a href=”#Proof”>`Proof` instances</a>, each contained in a separate graph). The property is used to provide a sequence of multiple proofs where the order of when the proofs occurred matters. The proof chain property is typically not included in the canonicalized graphs that are then separately digested and digitally signed.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:controller",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Controller",
+        "rdfs:comment": {
+            "@value": "<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:authentication",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Authentication method",
+        "rdfs:comment": {
+            "@value": "<div>An `authentication` property is used to specify a URL that contains information about a `verificationMethod` used for authentication.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:assertionMethod",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Assertion method",
+        "rdfs:comment": {
+            "@value": "<div>An `assertionMethod` property is used to specify a URL that contains information about a `verificationMethod` used for assertions.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:capabilityDelegation",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Capability Delegation Method",
+        "rdfs:comment": {
+            "@value": "<div><p>A `capabilityDelegation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of delegating capabilities.</p>\n<p>A `verificationMethod` may be referenced by its identifier (a URL) or expressed in full.</p>\n<p>The aforementioned proofs are created to prove that some entity is delegating the authority to take some action to another entity. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityDelegation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that has a property of `capabilityDelegation` that references the `verificationMethod`. This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:capabilityInvocation",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Capability Invocation Method",
+        "rdfs:comment": {
+            "@value": "<div><p>A `capabilityInvocation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of invoking capabilities.</p>\n<p>A `verificationMethod` MAY be referenced by its identifier (a URL) or expressed in full.</p>\n<p>The aforementioned proofs are created to prove that some entity is attempting to exercise some authority they possess to take an action. A verifier of the proof should expect the proof to express a `proofPurpose` of `capabilityInvocation` and reference a `verificationMethod` to verify it. The dereferenced `verificationMethod` MUST have a controller property that, when dereferenced, has a property of `capabilityInvocation` that references the `verificationMethod.` This indicates that the controller has authorized it for the expressed `proofPurpose`.</p></div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:keyAgreement",
+        "@type": ["rdf:Property", "owl:ObjectProperty"],
+        "rdfs:range": "sec:VerificationMethod",
+        "rdfs:label": "Key agreement protocols",
+        "rdfs:comment": {
+            "@value": "<div>Indicates that a proof is used for for key agreement protocols, such as Elliptic Curve Diffie Hellman key agreement used by popular encryption libraries.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:cryptosuite",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:DataIntegrityProof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Cryptographic suite",
+        "rdfs:comment": {
+            "@value": "<div>A text-based identifier for a specific cryptographic suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof"]
+    }, {
+        "@id": "sec:publicKeyMultibase",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:VerificationMethod",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Public key multibase",
+        "rdfs:comment": {
+            "@value": "<div>The public key multibase property is used to specify the multibase-encoded version of a public key. The contents of the property are defined by specifications such as ED25519-2020 and listed in the Linked Data Cryptosuite Registry. Most public key type definitions are expected to:\n<ul>\n<li>Specify only a single encoding base per public key type as it reduces implementation burden and increases the chances of reaching broad interoperability.\n<li>Specify a multicodec header on the encoded public key to aid encoding and decoding applications in confirming that they are serializing and deserializing an expected public key type.\n<li>Use compressed binary formats to ensure efficient key sizes.\n</ul></div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://datatracker.ietf.org/doc/html/draft-multiformats-multibase-03", "https://w3c-ccg.github.io/ld-cryptosuite-registry/", "https://github.com/multiformats/multicodec/blob/master/table.csv", "https://w3c-ccg.github.io/lds-ed25519-2020/"]
+    }, {
+        "@id": "sec:publicKeyJwk",
+        "@type": ["rdf:Property", "owl:DatatypeProperty"],
+        "rdfs:domain": "sec:VerificationMethod",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Public key JWK",
+        "rdfs:comment": {
+            "@value": "<div>See the JOSE suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://www.iana.org/assignments/jose/jose.xhtml", "https://tools.ietf.org/html/rfc7517"]
+    }, {
+        "@id": "sec:cipherAlgorithm",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:EncryptedMessage",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Cipher algorithm",
+        "rdfs:comment": {
+            "@value": "<div>The cipher algorithm describes the mechanism used to encrypt a message. It is typically a string expressing the cipher suite, the strength of the cipher, and a block cipher mode.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:cipherData",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:EncryptedMessage",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Cipher data",
+        "rdfs:comment": {
+            "@value": "<div>Cipher data is an opaque blob of information that is used to specify an encrypted message.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:cipherKey",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:EncryptedMessage",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Cipher key",
+        "rdfs:comment": {
+            "@value": "<div>A cipher key is a symmetric key that is used to encrypt or decrypt a piece of information. The key itself may be expressed in clear text or encrypted.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:digestAlgorithm",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Digest algorithm",
+        "rdfs:comment": {
+            "@value": "<div>The digest algorithm is used to specify the cryptographic function to use when generating the data to be digitally signed. Typically, data that is to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step 2. A signature class typically specifies a default digest method, so this property is typically used to specify information for a signature algorithm.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:digestValue",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Digest value",
+        "rdfs:comment": {
+            "@value": "<div>The digest value is used to express the output of the digest algorithm expressed in Base-16 (hexadecimal) format.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:blockchainAccountId",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Blockchain account ID",
+        "rdfs:comment": {
+            "@value": "<div>A `blockchainAccountId` property is used to specify a blockchain account identifier, as per the <a href=”https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md”>CAIP-10Account ID Specification</a>.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:ethereumAddress",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Ethereum address",
+        "rdfs:comment": {
+            "@value": "<div>An `ethereumAddress` property is used to specify the Ethereum address. As per the Ethereum Yellow Paper “Ethereum: a secure decentralised generalised transaction ledger” in consists of a prefix \"0x\", a common identifier for hexadecimal, concatenated with the rightmost 20 bytes of the Keccak-256 hash (big endian) of the ECDSA public key (the curve used is the so-called secp256k1). In hexadecimal, 2 digits represent a byte, meaning addresses contain 40 hexadecimal digits. The Ethereum address should also contain a checksum as per EIP-55.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://eips.ethereum.org/EIPS/eip-55", "https://ethereum.github.io/yellowpaper/paper.pdf"]
+    }, {
+        "@id": "sec:expires",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:dateTime",
+        "rdfs:label": "Expiration time",
+        "rdfs:comment": {
+            "@value": "<div>The expiration time is typically associated with a <a href=”#Key>`Key`</a> and specifies when the validity of the key will expire.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:initializationVector",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:EncryptedMessage",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Initialization vector",
+        "rdfs:comment": {
+            "@value": "<div>The initialization vector (IV) is a byte stream that is typically used to initialize certain block cipher encryption schemes. For a receiving application to be able to decrypt a message, it must know the decryption key and the initialization vector. The value is typically base-64 encoded.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:nonce",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Nonce",
+        "rdfs:comment": {
+            "@value": "<div>This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:canonicalizationAlgorithm",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:label": "Canonicalization algorithm",
+        "rdfs:comment": {
+            "@value": "<div>The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so on the same set of information in a deterministic manner.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:controller",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Controller",
+        "rdfs:comment": {
+            "@value": "<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:owner",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Owner (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>An owner is an entity that claims control over a particular resource. Note that ownership is best validated as a two-way relationship where the owner claims ownership over a particular resource, and the resource clearly identifies its owner.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:password",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Password",
+        "rdfs:comment": {
+            "@value": "<div>A secret that is used to generate a key that can be used to encrypt or decrypt message. It is typically a string value.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:privateKeyPem",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Key",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "PEM encoded private key",
+        "rdfs:comment": {
+            "@value": "<div>A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing private keys.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["http://en.wikipedia.org/wiki/Privacy_Enhanced_Mail"]
+    }, {
+        "@id": "sec:publicKey",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Key",
+        "rdfs:label": "Public Key",
+        "rdfs:comment": {
+            "@value": "<div>A public key property is used to specify a URL that contains information about a public key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:publicKeyBase58",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Key",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Base58-encoded Public Key",
+        "rdfs:comment": {
+            "@value": "<div>A public key Base58 property is used to specify the base58-encoded version of the public key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:publicKeyPem",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Key",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Public key PEM",
+        "rdfs:comment": {
+            "@value": "<div>A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions initializing public keys.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:publicKeyHex",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Key",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Hex-encoded version of public Key",
+        "rdfs:comment": {
+            "@value": "<div>A `publicKeyHex` property is used to specify the hex-encoded version of the public key, based on section 8 of rfc4648. Hex encoding is also known as Base16 encoding.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://tools.ietf.org/html/rfc4648#section-8"]
+    }, {
+        "@id": "sec:publicKeyService",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Public key service",
+        "rdfs:comment": {
+            "@value": "<div>The publicKeyService property is used to express the REST URL that provides public key management services.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:revoked",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "xsd:dateTime",
+        "rdfs:label": "Revocation time",
+        "rdfs:comment": {
+            "@value": "<div>The revocation time is typically associated with a <a href=”#Key”>`Key`</a> that has been marked as invalid as of the date and time associated with the property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation schedules.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:jws",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "sec:Signature",
+        "rdfs:label": "Json Web Signature",
+        "rdfs:comment": {
+            "@value": "<div>The jws property is used to associate a detached Json Web Signature with a proof.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://tools.ietf.org/html/rfc7797"]
+    }, {
+        "@id": "sec:challenge",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Challenge with a proof",
+        "rdfs:comment": {
+            "@value": "<div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:expirationDate",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Proof",
+        "rdfs:range": "xsd:dateTime",
+        "rdfs:label": "Expiration date for proof",
+        "rdfs:comment": {
+            "@value": "<div>The `expirationDate` property is used to associate an expiration date with a proof.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:signature",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:range": "sec:Signature",
+        "rdfs:label": "Signature  (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graph that is then digested, and digitally signed.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:signatureValue",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:DatatypeProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:range": "xsd:string",
+        "rdfs:label": "Signature value  (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>The signature value is used to express the output of the signature algorithm expressed in base-64 format.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:signatureAlgorithm",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:label": "Signature algorithm  (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital signatures.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:service",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:label": "Service",
+        "rdfs:comment": {
+            "@value": "<div>Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:serviceEndpoint",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:label": "Service endpoint",
+        "rdfs:comment": {
+            "@value": "<div>A network address at which a service operates on behalf of a controller. Examples of specific services include discovery services, social networks, file storage services, and verifiable claim repository services. Service endpoints might also be provided by a generalized data interchange protocol, such as extensible data interchange.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:x509CertificateChain",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:range": "sec:Signature",
+        "rdfs:label": "X509 Certificate chain",
+        "rdfs:comment": {
+            "@value": "<div>The x509CertificateChain property is used to associate a chain of X.509 Certificates with a proof. The value of this property is an ordered list where each value in the list is an X.509 Certificate expressed as a DER PKIX format, that is encoded with multibase using the base64pad variant. The certificate directly associated to the verification method used to verify the proof MUST be the first element in the list. Subsequent certificates in the list MAY be included where each one MUST certify the previous one.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://tools.ietf.org/html/rfc5280", "https://tools.ietf.org/id/draft-multiformats-multibase-00.html"]
+    }, {
+        "@id": "sec:x509CertificateFingerprint",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty", "owl:ObjectProperty"],
+        "owl:deprecated": true,
+        "rdfs:domain": "sec:Signature",
+        "rdfs:range": "sec:Signature",
+        "rdfs:label": "X509 Certificate fingerprint",
+        "rdfs:comment": {
+            "@value": "<div>The x509CertificateFingerprint property is used to associate an X.509 Certificate with a proof via its fingerprint. The value is a multihash encoded then multibase encoded value using the base64pad variant. It is RECOMMENDED that the fingerprint value be the SHA-256 hash of the X.509 Certificate.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://tools.ietf.org/html/rfc5280", "https://tools.ietf.org/id/draft-multiformats-multibase-00.html"]
+    }, {
+        "@id": "sec:allowedAction",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Allowed action",
+        "rdfs:comment": {
+            "@value": "<div>An action that the controller of a capability may take when invoking the capability.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#delegated-capability"]
+    }, {
+        "@id": "sec:capabilityChain",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Capability chain",
+        "rdfs:comment": {
+            "@value": "<div>An list of delegated capabilities from a delegator to a delegatee.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#delegation"]
+    }, {
+        "@id": "sec:capabilityAction",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Capability action",
+        "rdfs:comment": {
+            "@value": "<div>An action that can be taken given a capability.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#invoking-root-capability"]
+    }, {
+        "@id": "sec:caveat",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Caveat",
+        "rdfs:comment": {
+            "@value": "<div>A restriction on the way the capability may be used.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#caveats"]
+    }, {
+        "@id": "sec:delegator",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Delegator",
+        "rdfs:comment": {
+            "@value": "<div>An entity that delegates a capability to a delegatee.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#delegation"]
+    }, {
+        "@id": "sec:invocationTarget",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Invocation target",
+        "rdfs:comment": {
+            "@value": "<div>An invocation target identifies where a capability may be invoked, and identifies the target object for which the root capability expresses authority.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#root-capability"]
+    }, {
+        "@id": "sec:invoker",
+        "@type": ["rdf:Property", "owl:DeprecatedProperty"],
+        "owl:deprecated": true,
+        "rdfs:label": "Invoker",
+        "rdfs:comment": {
+            "@value": "<div>An identifier to cryptographic material that can invoke a capability.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/zcap-spec/#invocation"]
+    }, {
+        "@id": "sec:Proof",
+        "@type": "rdfs:Class",
+        "rdfs:label": "Digital proof",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a digital proof on serialized data. </div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:ProofGraph",
+        "@type": "rdfs:Class",
+        "rdfs:label": "An RDF Graph for a digital proof",
+        "rdfs:comment": {
+            "@value": "<div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Proof.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "reserved"
+    }, {
+        "@id": "sec:VerificationMethod",
+        "@type": "rdfs:Class",
+        "rdfs:label": "Verification method",
+        "rdfs:comment": {
+            "@value": "<div>A Verification Method class can express different verification methods, such as cryptographic public keys, which can be used to authenticate or authorize interaction with the `controller` or associated parties. Verification methods might take many parameters.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:DataIntegrityProof",
+        "@type": "rdfs:Class",
+        "rdfs:subClassOf": ["sec:Proof"],
+        "rdfs:label": "A Data Integrity Proof",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity proof used to encode a variety of cryptographic suite proof encodings.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://www.w3.org/TR/vc-data-integrity/#dataintegrityproof"]
+    }, {
+        "@id": "sec:Ed25519Signature2020",
+        "@type": "rdfs:Class",
+        "rdfs:subClassOf": ["sec:Proof"],
+        "rdfs:label": "ED2559 Signature Suite, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>T.B.D.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:Key",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:label": "Cryptographic key",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:Signature",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Proof"],
+        "rdfs:label": "Digital signature",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a digital signature on serialized data. It is an abstract class and should not be used other than for Semantic Web reasoning purposes, such as by a reasoning agent. This class MUST NOT be used directly, but only through its subclasses.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:SignatureGraph",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:ProofGraph"],
+        "rdfs:label": "An RDF Graph for a digital signature",
+        "rdfs:comment": {
+            "@value": "<div>Instances of this class are RDF Graphs, where each of these graphs must include exactly one Signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:EcdsaSecp256k1Signature2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"]
+    }, {
+        "@id": "sec:EcdsaSecp256k1Signature2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"]
+    }, {
+        "@id": "sec:EcdsaSecp256k1RecoverySignature2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverysignature2020"]
+    }, {
+        "@id": "sec:EcdsaSecp256k1VerificationKey2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity verification method.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsa-secp256k1"]
+    }, {
+        "@id": "sec:EcdsaSecp256k1RecoveryMethod2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity verification method.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ecdsasecp256k1recoverymethod2020"]
+    }, {
+        "@id": "sec:RsaSignature2018",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "Signature Suite for RSA (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa"]
+    }, {
+        "@id": "sec:RsaVerificationKey2018",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "Verification Key for RSA (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity verification method.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#rsa"]
+    }, {
+        "@id": "sec:SchnorrSecp256k1Signature2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature suite.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:SchnorrSecp256k1VerificationKey2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity verification method.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:ServiceEndpointProxyService",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:label": "TBD.",
+        "rdfs:comment": {
+            "@value": "<div>T.B.D.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:Digest",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:label": "Message digest",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a message digest that may be used for data integrity verification. The digest algorithm used will determine the cryptographic properties of the digest.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:EncryptedMessage",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:label": "Encrypted message",
+        "rdfs:comment": {
+            "@value": "<div>A class of messages that are obfuscated in some cryptographic manner. These messages are incredibly difficult to decrypt without the proper decryption key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:GraphSignature2012",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "RDF graph signature",
+        "rdfs:comment": {
+            "@value": "<div>A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:LinkedDataSignature2015",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "Linked data signature, 2015 version (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:LinkedDataSignature2016",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "Linked data signature, 2016 version (was deprecated in the CCG document)",
+        "rdfs:comment": {
+            "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:MerkleProof2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "Merkle Proof",
+        "rdfs:comment": {
+            "@value": "<div>Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and ECDSA to perform the digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/lds-merkle-proof-2019/"]
+    }, {
+        "@id": "sec:X25519KeyAgreementKey2019",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "X25519 Key Agreement Key 2019",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a verification key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:Ed25519VerificationKey2018",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "ED2559 Verification Key, 2018 version",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity verification method.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"]
+    }, {
+        "@id": "sec:Ed25519VerificationKey2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "ED2559 Verification Key, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>A linked data proof suite verification method type used with <a href=”#Ed25519Signature2020>`Ed25519Signature2020`</a>.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:JsonWebKey2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "JSON Web Key, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>A linked data proof suite verification method type used with <a href=”#JsonWebSignature2020>`JsonWebSignature2020`</a></div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:JsonWebSignature2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "JSON Web Signature, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and JWS to perform the digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:BbsBlsSignature2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "BBS Signature, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignature` digests each of the statements produced by the normalization process individually to enable selective disclosure. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:BbsBlsSignatureProof2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Signature"],
+        "rdfs:label": "BBS Signature Proof, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which deterministically names all unnamed nodes. Importantly, a `BbsBlsSignatureProof2020` is in fact a proof of knowledge of an unrevealed BbsBlsSignature2020 enabling the ability to selectively reveal information from the set that was originally signed. Each of the statements produced by the normalizing process for a JSON-LD document featuring a <a href=”#BbsBlsSignatureProof2020\">`BbsBlsSignatureProof2020`</a> represent statements that were originally signed in producing the `BbsBlsSignature2020` and represent the denomination under which information can be selectively disclosed. The signature mechanism uses Blake2B as the digest for each statement and produces a single output digital signature.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated"
+    }, {
+        "@id": "sec:Bls12381G1Key2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "BLS 12381 G1 Signature Key, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"]
+    }, {
+        "@id": "sec:Bls12381G2Key2020",
+        "@type": ["rdfs:Class", "owl:DeprecatedClass"],
+        "owl:deprecated": true,
+        "rdfs:subClassOf": ["sec:Key"],
+        "rdfs:label": "BLS 12381 G2 Signature Key, 2020 version",
+        "rdfs:comment": {
+            "@value": "<div>This class represents a data integrity signature key.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519"]
+    }, {
+        "@id": "sec:CredentialStatusRange",
+        "@type": "rdfs:Class",
+        "rdfs:label": "Credential status range",
+        "rdfs:comment": {
+            "@value": "<div>The range of possible values for the <code>sec:credentialStatus</code> property. This is an open enumeration: values beyond the ones listed here may also be valid.</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:SomeIndividual",
+        "@type": "cred:ABCD",
+        "rdfs:label": "Testing the individuals",
+        "rdfs:comment": {
+            "@value": "<div>A longer description for this individual</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable",
+        "rdfs:seeAlso": ["https://www.example.org/namivan/"]
+    }, {
+        "@id": "sec:DeprecatedIndividual",
+        "@type": "cred:XYXX",
+        "owl:deprecated": true,
+        "rdfs:label": "Testing the deprecated individuals",
+        "rdfs:comment": {
+            "@value": "<div>A longer description for this deprecated individual</div>",
+            "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"
+        },
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "deprecated",
+        "rdfs:seeAlso": ["https://www.example.org/namivan/deprecated"]
+    }, {
+        "@id": "sec:statusValid",
+        "@type": "sec:CredentialStatusRange",
+        "rdfs:label": "Status valid",
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }, {
+        "@id": "sec:statusRevoked",
+        "@type": "sec:CredentialStatusRange",
+        "rdfs:label": "Status revoked",
+        "rdfs:isDefinedBy": "https://w3id.org/security/v1",
+        "vs:term_status": "stable"
+    }]
 }

--- a/example/test.ttl
+++ b/example/test.ttl
@@ -13,13 +13,21 @@
 sec: a owl:Ontology ;
     dc:title """Security Vocabulary"""@en ;
     dc:description """vocabulary used to ensure the authenticity and integrity of Verifiable Credentials and similar types of constrained digital documents using cryptography, especially through the use of digital signatures and related mathematical proofs 
-"""@en ;
+"""^^rdf:HTML ;
     rdfs:seeAlso <https://www.w3.org/TR/vc-data-integrity/> ;
-    dc:date "2025-01-16"^^xsd:date ;
+    dc:date "2026-08-03"^^xsd:date ;
 .
 
 # Property definitions
-sec:verificationMethod a rdf:Property ;
+sec:credentialStatus a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:CredentialStatusRange ;
+    rdfs:label "Credential status" ;
+    rdfs:comment """<div>The status of the credential, restricted to a known, but extensible, set of values.</div>"""^^rdf:HTML ;
+    rdfs:isDefinedBy <https://w3id.org/security/v1> ;
+    vs:term_status "stable" ;
+.
+
+sec:verificationMethod a rdf:Property, owl:ObjectProperty ;
     rdfs:range sec:VerificationMethod ;
     rdfs:label "Verification method" ;
     rdfs:comment """<div>A `verificationMethod` property is used to specify a URL that contains information used for proof verification.</div>"""^^rdf:HTML ;
@@ -37,13 +45,14 @@ sec:domain a rdf:Property, owl:DatatypeProperty ;
     vs:term_status "stable" ;
 .
 
-sec:challenge a rdf:Property, owl:DatatypeProperty ;
+sec:challenge a rdf:Property, owl:DeprecatedProperty, owl:DatatypeProperty ;
+    owl:deprecated true ;
     rdfs:domain sec:Proof ;
     rdfs:range xsd:string ;
     rdfs:label "Challenge with a proof" ;
     rdfs:comment """<div>The challenge property is used to associate a challenge with a proof, for use with a `proofPurpose` such as `authentication`. This string value SHOULD be included in a proof if a `domain` is specified.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://w3id.org/security/v1> ;
-    vs:term_status "stable" ;
+    vs:term_status "deprecated" ;
 .
 
 sec:proofPurpose a rdf:Property, owl:DatatypeProperty ;
@@ -64,7 +73,7 @@ sec:proofValue a rdf:Property, owl:DatatypeProperty ;
     vs:term_status "stable" ;
 .
 
-sec:proof a rdf:Property ;
+sec:proof a rdf:Property, owl:ObjectProperty ;
     rdfs:range sec:ProofGraph ;
     rdfs:label "Proof sets" ;
     rdfs:comment """<div>The value of the `proof` property MUST identify <a href=”#ProofGraph”>`ProofGraph` instances</a> (informally, it indirectly identifies <a href=”#Proof”>`Proof` instances</a>, each contained in a separate graph). The property is used to associate a proof with a graph of information. The proof property is typically not included in the canonicalized graphs that are then digested and digitally signed. The order of the proofs is not relevant.</div>"""^^rdf:HTML ;
@@ -80,32 +89,32 @@ sec:proofChain a rdf:Property ;
     vs:term_status "stable" ;
 .
 
-sec:controller a rdf:Property, owl:ObjectProperty ;
-    rdfs:domain sec:VerificationMethod ;
+sec:controller a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
+    owl:deprecated true ;
     rdfs:label "Controller" ;
-    rdfs:comment """<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship, where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>"""^^rdf:HTML ;
+    rdfs:comment """<div>A controller is an entity that claims control over a particular resource. Note that control is best validated as a two-way relationship where the controller claims control over a particular resource, and the resource clearly identifies its controller.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://w3id.org/security/v1> ;
-    vs:term_status "stable" ;
+    vs:term_status "deprecated" ;
 .
 
-sec:authentication a rdf:Property ;
-    rdfs:range VerificationMethod ;
+sec:authentication a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:VerificationMethod ;
     rdfs:label "Authentication method" ;
     rdfs:comment """<div>An `authentication` property is used to specify a URL that contains information about a `verificationMethod` used for authentication.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://w3id.org/security/v1> ;
     vs:term_status "stable" ;
 .
 
-sec:assertionMethod a rdf:Property ;
-    rdfs:range VerificationMethod ;
+sec:assertionMethod a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:VerificationMethod ;
     rdfs:label "Assertion method" ;
     rdfs:comment """<div>An `assertionMethod` property is used to specify a URL that contains information about a `verificationMethod` used for assertions.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://w3id.org/security/v1> ;
     vs:term_status "stable" ;
 .
 
-sec:capabilityDelegation a rdf:Property ;
-    rdfs:range VerificationMethod ;
+sec:capabilityDelegation a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:VerificationMethod ;
     rdfs:label "Capability Delegation Method" ;
     rdfs:comment """<div><p>A `capabilityDelegation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of delegating capabilities.</p>
 <p>A `verificationMethod` may be referenced by its identifier (a URL) or expressed in full.</p>
@@ -114,8 +123,8 @@ sec:capabilityDelegation a rdf:Property ;
     vs:term_status "stable" ;
 .
 
-sec:capabilityInvocation a rdf:Property ;
-    rdfs:range VerificationMethod ;
+sec:capabilityInvocation a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:VerificationMethod ;
     rdfs:label "Capability Invocation Method" ;
     rdfs:comment """<div><p>A `capabilityInvocation` property is used to express that one or more `verificationMethods` are authorized to verify cryptographic proofs that were created for the purpose of invoking capabilities.</p>
 <p>A `verificationMethod` MAY be referenced by its identifier (a URL) or expressed in full.</p>
@@ -124,8 +133,8 @@ sec:capabilityInvocation a rdf:Property ;
     vs:term_status "stable" ;
 .
 
-sec:keyAgreement a rdf:Property ;
-    rdfs:range VerificationMethod ;
+sec:keyAgreement a rdf:Property, owl:ObjectProperty ;
+    rdfs:range sec:VerificationMethod ;
     rdfs:label "Key agreement protocols" ;
     rdfs:comment """<div>Indicates that a proof is used for for key agreement protocols, such as Elliptic Curve Diffie Hellman key agreement used by popular encryption libraries.</div>"""^^rdf:HTML ;
     rdfs:isDefinedBy <https://w3id.org/security/v1> ;
@@ -365,7 +374,7 @@ sec:revoked a rdf:Property, owl:DeprecatedProperty, owl:DatatypeProperty ;
     vs:term_status "deprecated" ;
 .
 
-sec:jws a rdf:Property, owl:DeprecatedProperty ;
+sec:jws a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
     owl:deprecated true ;
     rdfs:range sec:Signature ;
     rdfs:label "Json Web Signature" ;
@@ -395,7 +404,7 @@ sec:expirationDate a rdf:Property, owl:DeprecatedProperty, owl:DatatypeProperty 
     vs:term_status "deprecated" ;
 .
 
-sec:signature a rdf:Property, owl:DeprecatedProperty ;
+sec:signature a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
     owl:deprecated true ;
     rdfs:range sec:Signature ;
     rdfs:label "Signature  (was deprecated in the CCG document)" ;
@@ -441,7 +450,7 @@ sec:serviceEndpoint a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
     vs:term_status "deprecated" ;
 .
 
-sec:x509CertificateChain a rdf:Property, owl:DeprecatedProperty ;
+sec:x509CertificateChain a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
     owl:deprecated true ;
     rdfs:domain sec:Signature ;
     rdfs:range sec:Signature ;
@@ -452,7 +461,7 @@ sec:x509CertificateChain a rdf:Property, owl:DeprecatedProperty ;
     rdfs:seeAlso <https://tools.ietf.org/html/rfc5280>, <https://tools.ietf.org/id/draft-multiformats-multibase-00.html> ;
 .
 
-sec:x509CertificateFingerprint a rdf:Property, owl:DeprecatedProperty ;
+sec:x509CertificateFingerprint a rdf:Property, owl:DeprecatedProperty, owl:ObjectProperty ;
     owl:deprecated true ;
     rdfs:domain sec:Signature ;
     rdfs:range sec:Signature ;
@@ -824,6 +833,13 @@ sec:Bls12381G2Key2020 a rdfs:Class, owl:DeprecatedClass ;
     rdfs:seeAlso <https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519> ;
 .
 
+sec:CredentialStatusRange a rdfs:Class ;
+    rdfs:label "Credential status range" ;
+    rdfs:comment """<div>The range of possible values for the <code>sec:credentialStatus</code> property. This is an open enumeration: values beyond the ones listed here may also be valid.</div>"""^^rdf:HTML ;
+    rdfs:isDefinedBy <https://w3id.org/security/v1> ;
+    vs:term_status "stable" ;
+.
+
 
 
 # Definitions of individuals
@@ -844,96 +860,16 @@ sec:DeprecatedIndividual a cred:XYXX ;
     rdfs:seeAlso <https://www.example.org/namivan/deprecated> ;
 .
 
-# Context files and their mentions
-<vocab> a jsonld:Context ;
-    schema:mentions
-        sec:verificationMethod,
-        sec:domain,
-        sec:challenge,
-        sec:proofPurpose,
-        sec:proofValue,
-        sec:proof,
-        sec:proofChain,
-        sec:controller,
-        sec:authentication,
-        sec:assertionMethod,
-        sec:capabilityDelegation,
-        sec:capabilityInvocation,
-        sec:keyAgreement,
-        sec:cryptosuite,
-        sec:publicKeyMultibase,
-        sec:publicKeyJwk,
-        sec:cipherAlgorithm,
-        sec:cipherData,
-        sec:cipherKey,
-        sec:digestAlgorithm,
-        sec:digestValue,
-        sec:blockchainAccountId,
-        sec:ethereumAddress,
-        sec:expires,
-        sec:initializationVector,
-        sec:nonce,
-        sec:canonicalizationAlgorithm,
-        sec:controller,
-        sec:owner,
-        sec:password,
-        sec:privateKeyPem,
-        sec:publicKey,
-        sec:publicKeyBase58,
-        sec:publicKeyPem,
-        sec:publicKeyHex,
-        sec:publicKeyService,
-        sec:revoked,
-        sec:jws,
-        sec:challenge,
-        sec:expirationDate,
-        sec:signature,
-        sec:signatureValue,
-        sec:signatureAlgorithm,
-        sec:service,
-        sec:serviceEndpoint,
-        sec:x509CertificateChain,
-        sec:x509CertificateFingerprint,
-        sec:allowedAction,
-        sec:capabilityChain,
-        sec:capabilityAction,
-        sec:caveat,
-        sec:delegator,
-        sec:invocationTarget,
-        sec:invoker,
-        sec:Proof,
-        sec:ProofGraph,
-        sec:VerificationMethod,
-        sec:DataIntegrityProof,
-        sec:Ed25519Signature2020,
-        sec:Key,
-        sec:Signature,
-        sec:SignatureGraph,
-        sec:EcdsaSecp256k1Signature2019,
-        sec:EcdsaSecp256k1Signature2020,
-        sec:EcdsaSecp256k1RecoverySignature2020,
-        sec:EcdsaSecp256k1VerificationKey2019,
-        sec:EcdsaSecp256k1RecoveryMethod2020,
-        sec:RsaSignature2018,
-        sec:RsaVerificationKey2018,
-        sec:SchnorrSecp256k1Signature2019,
-        sec:SchnorrSecp256k1VerificationKey2019,
-        sec:ServiceEndpointProxyService,
-        sec:Digest,
-        sec:EncryptedMessage,
-        sec:GraphSignature2012,
-        sec:LinkedDataSignature2015,
-        sec:LinkedDataSignature2016,
-        sec:MerkleProof2019,
-        sec:X25519KeyAgreementKey2019,
-        sec:Ed25519VerificationKey2018,
-        sec:Ed25519VerificationKey2020,
-        sec:JsonWebKey2020,
-        sec:JsonWebSignature2020,
-        sec:BbsBlsSignature2020,
-        sec:BbsBlsSignatureProof2020,
-        sec:Bls12381G1Key2020,
-        sec:Bls12381G2Key2020,
-        sec:SomeIndividual,
-        sec:DeprecatedIndividual ;
+sec:statusValid a sec:CredentialStatusRange ;
+    rdfs:label "Status valid" ;
+    rdfs:isDefinedBy <https://w3id.org/security/v1> ;
+    vs:term_status "stable" ;
+.
 
+sec:statusRevoked a sec:CredentialStatusRange ;
+    rdfs:label "Status revoked" ;
+    rdfs:isDefinedBy <https://w3id.org/security/v1> ;
+    vs:term_status "stable" ;
+.
+
+# Context files and their mentions

--- a/example/test.yml
+++ b/example/test.yml
@@ -253,6 +253,12 @@ class:
         url: https://w3c-ccg.github.io/ld-cryptosuite-registry/#ed25519
 
 property:
+  - id: credentialStatus
+    label: Credential status
+    comment: The status of the credential, restricted to a known, but extensible, set of values.
+    one_of: [sec:statusValid, sec:statusRevoked]
+    open_enumeration: true
+
   - id: verificationMethod
     label: Verification method
     range: sec:VerificationMethod

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -214,6 +214,7 @@ export interface RawVocabEntry {
     container   ?: Container;
     context     ?: string[];
     one_of      ?: string[];
+    open_enumeration ?: boolean;
     pattern     ?: string;
 }
 
@@ -369,6 +370,7 @@ export interface RDFProperty extends RDFTerm {
     range         : RDFTerm[];  // Can be a class or a datatype and, even, an unknown term
     range_union   : boolean;
     one_of        : RDFIndividual[];
+    open_enumeration : boolean; // Whether the one_of values are a closed or open enumeration
     dataset       : boolean;
     container     : Container | undefined;
     strongURL     : boolean;    // Whether the property object should be required to be a real URL

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -30,6 +30,18 @@ function isURL(value:string): boolean {
 }
 
 /**
+ * Capitalize the first character of a string; used to derive the name of the
+ * fresh class generated for a property's `open_enumeration`.
+ *
+ * @param str
+ * @returns
+ * @internal
+ */
+function capitalize(str: string): string {
+    return str.length === 0 ? str : str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
  * Turn the id text into a non-camel case for a label.
  *
  * @param str
@@ -232,6 +244,7 @@ function finalizeRawEntry(raw: RawVocabEntry): RawVocabEntry {
         context     : toArrayContexts(raw.context),
         pattern     : raw.pattern,
         one_of      : toArray(raw.one_of) as undefined | string[],
+        open_enumeration : raw.open_enumeration ?? false,
     }
 }
 
@@ -410,6 +423,10 @@ export function getData(vocab_source: string): Vocab {
                 }
             }
         }
+        if (raw.one_of && raw.one_of.length > 0) {
+            extra_types.push("owl:ObjectProperty");
+        }
+
 
         extra_types = [ ...new Set(extra_types) ];  // remove duplicates
         // In fact, the length of the types must be 0 or 1, otherwise, it is a general property that can have any range
@@ -634,6 +651,13 @@ export function getData(vocab_source: string): Vocab {
     ) : [];
 
     /********************************************************************************************/
+    // Bookkeeping for the `open_enumeration` flag on a property's `one_of`: the fresh, named
+    // range classes that get generated, and the (one_of value -> generated class) memberships
+    // that must be turned into `rdf:type` relationships once the individuals are all known.
+    const openEnumClasses: RDFClass[] = [];
+    const openEnumMemberships: { id: string, cls: RDFClass }[] = [];
+
+    /********************************************************************************************/
     // Get the properties. Note the special treatment for deprecated properties, as well as
     // the extra owl types added depending on the range.
     //
@@ -654,11 +678,61 @@ export function getData(vocab_source: string): Vocab {
             // Calculate the ranges, which can be a mixture of classes, datatypes, and unknown terms
             const { extra_types, range, strongURL, langString } = get_ranges(factory, raw, output.id);
 
+            // Handling of `open_enumeration`: instead of the `one_of` values ending up in an
+            // anonymous `owl:oneOf` class (see `multiRange` in the turtle/jsonld modules), a fresh,
+            // named class is created (and added to the vocabulary's classes) to serve as the
+            // property's range; the `one_of` values are later declared as instances of that class.
+            const openEnumRangeClass = ((): RDFClass | undefined => {
+                if (!raw.open_enumeration) return undefined;
+                if (!raw.one_of || raw.one_of.length === 0) {
+                    throw new Error(`${output.curie} sets "open_enumeration" but has no "one_of" values.`);
+                }
+                if (output.external) {
+                    // External properties are not given formal RDF statements anyway
+                    return undefined;
+                }
+                if (extra_types.includes("owl:DatatypeProperty")) {
+                    throw new Error(`${output.curie} is a DatatypeProperty; "open_enumeration" can only be used for ObjectProperties.`);
+                }
+                const rangeClassId = `${capitalize(output.id)}Range`;
+                if (factory.has(rangeClassId)) {
+                    throw new Error(`Cannot create the automatic "open_enumeration" range class "${rangeClassId}" for property ${output.curie}: a term with that name is already defined.`);
+                }
+                const rangeClass: RDFClass = factory.class(rangeClassId);
+                const classTypes: string[] = (raw.status === Status.deprecated) ? ["rdfs:Class", "owl:DeprecatedClass"] : ["rdfs:Class"];
+                Object.assign(rangeClass, {
+                    type                  : classTypes.map(t => factory.term(t)),
+                    user_type             : [],
+                    label                 : `${raw.label} range`,
+                    comment               : `The range of possible values for the <code>${output.curie}</code> property. This is an open enumeration: values beyond the ones listed here may also be valid.`,
+                    deprecated            : raw.deprecated,
+                    status                : raw.status,
+                    subClassOf            : [],
+                    upper_union           : false,
+                    one_of                : [],
+                    context               : [],
+                    range_of              : [],
+                    domain_of             : [],
+                    included_in_domain_of : [],
+                    includes_range_of     : [],
+                });
+                global.status_counter.add(raw.status ? raw.status : Status.stable);
+                openEnumClasses.push(rangeClass);
+                for (const val of raw.one_of) {
+                    openEnumMemberships.push({ id: val, cls: rangeClass });
+                }
+                return rangeClass;
+            })();
+
             // A little hack to ensure backward compatibility: if the range includes rdf:List,
             // it should be removed and the information put aside because that should now
             // go to the separate "container" information.
-            const finalRange   = range.filter ((r: RDFTerm): boolean => r.curie !== "rdf:List");
-            const containerSet = (finalRange.length !== range.length);
+            const range2 = range.filter ((r: RDFTerm): boolean => r.curie !== "rdf:List");
+            const containerSet = (range2.length !== range.length);
+
+            // If this property accepts an open enumeration,
+            // add the generated class in its range.
+            const finalRange = openEnumRangeClass ? [...range2, openEnumRangeClass] : range2;
 
             const user_type: string[] = (raw.type === undefined) ? [] : raw.type
             const types: string[] = [
@@ -709,6 +783,7 @@ export function getData(vocab_source: string): Vocab {
                 range         : finalRange,
                 range_union   : (langString === true) ? true : raw.range_union,
                 one_of        : raw.one_of?.map((val: string): RDFIndividual => factory.individual(val)),
+                open_enumeration : raw.open_enumeration ?? false,
                 domain        : raw.domain?.map(val => factory.class(val)),
                 example       : raw.example,
                 known_as      : raw.known_as,
@@ -753,6 +828,40 @@ export function getData(vocab_source: string): Vocab {
             return output;
         }
     ) : [];
+
+    /********************************************************************************************/
+    // Add the classes that were auto-generated by properties using `open_enumeration`.
+    classes.push(...openEnumClasses);
+
+    /********************************************************************************************/
+    // Turn the `open_enumeration` memberships into `rdf:type` relationships: each `one_of` value
+    // becomes an instance of the fresh range class generated for its property. Values that are not
+    // otherwise explicitly defined via an `individual:` block get a minimal individual entry
+    // synthesized for them (recognizable by their still-empty label at this point), so that they
+    // are actually listed, and get their `rdf:type`, in the generated vocabulary. External values
+    // (defined in another vocabulary) are left untouched, in line with the rest of the tool's
+    // handling of external terms.
+    for (const { id, cls } of openEnumMemberships) {
+        const ind = factory.individual(id);
+        if (ind.prefix !== global.vocab_prefix) continue;
+
+        if (!ind.type.some((t: RDFTerm): boolean => t.curie === cls.curie)) {
+            ind.type.push(cls);
+        }
+
+        if (!ind.label) {
+            Object.assign(ind, {
+                label      : localeUnCamelise(ind.id),
+                comment    : '',
+                deprecated : false,
+                defined_by : [],
+                status     : Status.stable,
+                context    : [],
+            });
+            global.status_counter.add(Status.stable);
+            individuals.push(ind);
+        }
+    }
 
     /********************************************************************************************/
     // Set the domain and range of the back references for ranges/domains for classes and datatypes.

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -704,7 +704,7 @@ export function getData(vocab_source: string): Vocab {
                     type                  : classTypes.map(t => factory.term(t)),
                     user_type             : [],
                     label                 : `${raw.label} range`,
-                    comment               : `The range of possible values for the <code>${output.curie}</code> property. This is an open enumeration: values beyond the ones listed here may also be valid.`,
+                    comment               : `The range of possible values for the <code>${output.curie}</code> property. This is an open enumeration: values beyond those specified in this vocabulary may also be valid.`,
                     deprecated            : raw.deprecated,
                     status                : raw.status,
                     subClassOf            : [],

--- a/lib/html.ts
+++ b/lib/html.ts
@@ -563,7 +563,7 @@ export function toHTML(vocab: Vocab, template_text: string, basename: string, co
                             if (item.one_of && item.one_of.length > 0) {
                                 const dl = document.addChild(pr_section, 'dl');
                                 dl.className = 'terms';
-                                document.addChild(dl, 'dt', 'Value may be one of:');
+                                document.addChild(dl, 'dt', item.open_enumeration ? 'Suggested values include:' : 'Value may be one of:');
                                 const dd = document.addChild(dl, 'dd');
                                 dd.innerHTML = ((t: RDFTerm[]): string => {
                                     const join_logic = ', ';

--- a/lib/jsonld.ts
+++ b/lib/jsonld.ts
@@ -191,7 +191,9 @@ export function toJSONLD(vocab: Vocab): string {
             if (prop.container === Container.list) {
                 pr_object["rdfs:range"] = "rdf:List";
             } else if (prop.range?.length > 0 || prop.one_of?.length > 0) {
-                const range = multiRange(prop.range, prop.range_union, prop.one_of);
+                // When the enumeration is open, the one_of values are not turned into an
+                // anonymous owl:oneOf class; instead, a fresh named class was added to prop.range.
+                const range = multiRange(prop.range, prop.range_union, prop.open_enumeration ? undefined : prop.one_of);
                 pr_object["rdfs:range"] = range.length > 1 ? range : range[0];
             }
             commonFields(pr_object, prop);

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -178,6 +178,9 @@ const vocabSchema = `{
                             "one_of" : {
                                 "$ref": "#/$defs/StringOrArrayOfStrings"
                             },
+                            "open_enumeration" : {
+                                "type" : "boolean"
+                            },
                             "dataset": {
                                 "type": "boolean"
                             },

--- a/lib/turtle.ts
+++ b/lib/turtle.ts
@@ -164,7 +164,9 @@ export function toTurtle(vocab: Vocab): string {
                 if (prop.container === Container.list) {
                     turtle += `${spaces}rdfs:range rdf:List ;\n` ;
                 } else if (prop.range?.length > 0 || prop.one_of?.length > 0) {
-                    const range = multiRange(prop.range, prop.range_union, prop.one_of);
+                    // When the enumeration is open, the one_of values are not turned into an
+                    // anonymous owl:oneOf class; instead, a fresh named class was added to prop.range.
+                    const range = multiRange(prop.range, prop.range_union, prop.open_enumeration ? undefined : prop.one_of);
                     if (!(range === '' || range === '[]')) {
                         turtle += `${spaces}rdfs:range ${range} ;\n`;
                     }


### PR DESCRIPTION
The use-case for this is the following:
we want a list of "expected" value for a property, with those values having short names in the JSON-LD context,
but we do not want to semantically *restrict* the allowed values to those (the list of values is not closed).

This is conveyed by adding the attribute `open_enumeration: true` to a property block using `one_of`.
This does not change the JSON-LD context, but it changes the OWL description of the property:

instead of using `owl:oneOf` as the range of that property, a class named <PropertyName>Range is created,
with all individuals in the `one_of` list being declared as instances of that class.

NB1: this PR was created largely by Claude, and reviewed by myself.

NB2: the diffs in `examples/test.ttl`, `examples/test.jsonld` and `examples/test.html` are misleading, because the previous version of the files were generated with a much older version of yml2vocab... I did check that this PR does not induce any change in the generated files beyond those intended.
