### PR TITLE
Added a flag for the usage of `@protected`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 This list does not include all the tiny, e.g., editorial changes, only the changes in the features and more important bug issues.
 
-## Version 1.10.5
+## Version 1.11.0
 
 - If a term sets the `context` property to `none`, then it will not be added to the generated context (if applicable).
+- A new, optional `@protected` key is added to the `json_ld` block on whether the generated context and scoped context should include a `"@protected":true`. Default is `true`.
 
 ## Version 1.10.4
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,16 @@ The script automatically adds a `dc:date` key with the generation time as a valu
             </td>
             <td>No</td>
         </tr>
+        <tr>
+            <td><code>protected</code></td>
+            <td>boolean</td>
+            <td>
+                If the value is <code>true</code>, a <code>"@protected" : true</code> key is added to the context, as well as
+                all scoped contexts. This makes the context file safer when it is part of several context files referred to in a
+                JSON-LD file. Default value is <code>true</code>.
+            </td>
+            <td>No</td>
+        </tr>
     </tbody>
 </table>
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "@iherman/yml2vocab",
     "description": "Generation of vocabulary files starting by YAML",
-    "version": "1.10.5",
+    "version": "1.11.0",
     "homepage": "https://github.com/w3c/yml2vocab",
     // We do not want to use the npm installation from deno
     // npm packages used by the code is maintained separately

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -77,10 +77,14 @@ export class StatusCounter {
     }
 }
 
+/**
+ * Flags/features controlling the generated JSON-LD and JSON-LD context
+ */
 export interface JSON_LD {
     alias     ?: Record<string,string>;
     import    ?: string | string[];
-    set_vocab ?: boolean
+    set_vocab ?: boolean;
+    protected ?: boolean;
 }
 
 /**
@@ -142,6 +146,11 @@ export interface GlobalData {
      * value in the context using "@vocab".
      */
     set_vocab        ?: boolean;
+
+    /**
+     * Whether the "@protected" keyword should be added to the context (and scoped contexts)
+     */
+    protected        ?: boolean,
 }
 
 /**

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -15,12 +15,6 @@ interface Context {
     [index: string]: string | string[] | Context | boolean | null  ;
 }
 
-// These are the context statements appearing in all
-// embedded contexts, as well as the top level one.
-const preamble: Context = {
-    "@protected" : true,
-};
-
 // Minor utility: return the full URL for a prefix
 function prefix_url(prefix: string | undefined, vocab: Vocab): string {
     if (!prefix) {
@@ -125,6 +119,18 @@ export function toContext(vocab: Vocab): string {
         // no need for an indirection
         return Object.keys(output).length === 1 ? url : output;
     };
+
+
+    // These are the context statements appearing in all
+    const preamble: Context = ((): Context => {
+        if (global.protected === undefined || global.protected === true) {
+            return {
+                "@protected": true,
+            };
+        } else {
+            return {};
+        }
+    })();
 
     const set_vocab = (() : Context => {
         if (global.set_vocab) {

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -892,6 +892,7 @@ export function getData(vocab_source: string): Vocab {
 
     /********************************************************************************************/
     // The alias and import settings are not relevant for the individual terms, are to be set in the global space
+
     if (vocab.json_ld?.alias) {
         global.aliases = { ...global.aliases, ...vocab.json_ld.alias };
     }
@@ -901,6 +902,7 @@ export function getData(vocab_source: string): Vocab {
     }
 
     global.set_vocab = vocab.json_ld?.set_vocab ?? false;
+    global.protected = vocab.json_ld?.protected ?? true;
 
     /********************************************************************************************/
     // We're all set: return the internal representation of the vocabulary

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -85,6 +85,9 @@ const vocabSchema = `{
                 "set_vocab" : {
                     "type" : "boolean"
                 },
+                "protected" : {
+                    "type" : "boolean"
+                },
                 "unevaluatedProperties": false
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "yml2vocab",
-    "version": "1.10.5",
+    "version": "1.11.0",
     "description": "Generation of vocabulary files starting by YAML",
     "homepage": "https://github.com/w3c/yml2vocab",
     "repository": {


### PR DESCRIPTION
As the title says: until now, `@protected` is _always_ added to all generated context files, including the scoped contexts. This change adds a `protected` boolean valued key to the json-ld block to control whethere `@protected` should be added or not.

For backward compatibility reasons the key is optional, and default value is `true`.